### PR TITLE
spack-reusable: investigate cmake and gcc usage

### DIFF
--- a/.github/workflows/spack-reusable.yml
+++ b/.github/workflows/spack-reusable.yml
@@ -21,6 +21,9 @@ jobs:
         shell: bash
         run : |
           source /spack/share/spack/setup-env.sh
+          spack external find cmake
+          spack compiler list
+          spack compiler info gcc
           cd /spack_recipes && git pull
           spack repo add /spack_recipes/meshing
           spack repo add /spack_recipes/meshing_supersede


### PR DESCRIPTION
In our `spack-cgcore-1.8` container the dependencies were built using spack against `cmake-3.30.5`.

In our products CIs that use spack-reusable.yml it seems that `cmake-3.27.9` (the preferred version in spack-0.22.2) is used for the packages to compile :
https://github.com/LIHPC-Computational-Geometry/magix3d/actions/runs/11831454053/job/32966626392#step:5:43

Adding the call to `spack external find cmake` seems to address to anomaly and now we make use of the `cmake-3.30.5` declared as external; as an added bonus we gain 7min in the CIs execution time (see https://github.com/LIHPC-Computational-Geometry/magix3d/actions/runs/11864380050/job/33067703385)

I am not sure why it is necessary to make this call to find cmake, as the spack user configuration files from the container should have stored this info, whereas we do not need to make a call to find the compiler.
