### PR TITLE
added clone of magix3d_test_data_dir in the spack/cmake-reusable.yml CI

### DIFF
--- a/.github/workflows/cmake-reusable.yml
+++ b/.github/workflows/cmake-reusable.yml
@@ -51,6 +51,8 @@ jobs:
         shell: bash
         run: |
           cd test_link/
+          git clone --recurse-submodules https://github.com/LIHPC-Computational-Geometry/magix3d_test_data_dir.git
+          export MAGIX3D_TEST_DATA_DIR=$PWD/magix3d_test_data_dir
           cp ../CMakePresets.json .
           # Do not use ${{ github.event.repository.name }}_ROOT variable: package names != project names (sometimes)
           cmake -S . -B build --preset=ci -DCMAKE_PREFIX_PATH=$INSTALL_DIR/${{ github.event.repository.name }}

--- a/.github/workflows/spack-reusable.yml
+++ b/.github/workflows/spack-reusable.yml
@@ -76,6 +76,8 @@ jobs:
 
           # build test_link and run tests
           cd test_link/
+          git clone --recurse-submodules https://github.com/LIHPC-Computational-Geometry/magix3d_test_data_dir.git
+          export MAGIX3D_TEST_DATA_DIR=$PWD/magix3d_test_data_dir
           cmake -S . -B build
           cmake --build build
           cmake --build build --target test


### PR DESCRIPTION
The CIs now include the use of an external project that contains data necessary for the tests, https://github.com/LIHPC-Computational-Geometry/magix3d_test_data_dir