### PR TITLE
updated spack-0.23.1 for the check-push workflow

### DIFF
--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Initialize Spack environment
         shell: bash
         run: |
-          git clone --depth=1 -b releases/latest https://github.com/spack/spack.git ${{github.workspace}}/spack
+          git clone --depth=1 -b v0.23.1 https://github.com/spack/spack.git ${{github.workspace}}/spack
           source ${{github.workspace}}/spack/share/spack/setup-env.sh
           spack repo add ${{github.workspace}}/meshing
           spack repo add ${{github.workspace}}/meshing_supersede


### PR DESCRIPTION
Fixed the version of spack to 0.23.1 used in our `check-push`  workflow instead of the latest (1.0.0 as of now)