### PR TITLE
Package api v2.2 migration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,24 @@
+# -*- conf -*-
+# This is the only flake8 rule Spack violates somewhat flagrantly
+# - E731: do not assign a lambda expression, use a def
+#
+# This is the only flake8 exception needed when using Black.
+# - E203: white space around slice operators can be required, ignore : warn
+#
+# We still allow these in packages
+# - F403: from/import * used; unable to detect undefined names
+# - F405: undefined name or from *
+# - F821: undefined name (needed with from/import *)
+#
 [flake8]
+extend-ignore = E731,E203
 max-line-length = 99
-extend-ignore = F403,F405
+per-file-ignores =
+  */package.py:F403,F405,F821
+# format = spack
+
+# [flake8:local-plugins]
+# report =
+#   spack = flake8_formatter:SpackFormatter
+# paths =
+#   ./spack-core/share/spack/qa/

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Flake8 on meshing
         uses: py-actions/flake8@v2
         with:
-          ignore: "E501,F405,F403"
+          flake8-version: "7.3.0"
           path: "spack_repo/lihpc/meshing"
 
       - name: Flake8 on meshing_supersede
         uses: py-actions/flake8@v2
         with:
-          ignore: "E501,F405,F403,W504"
+          flake8-version: "7.3.0"
           path: "spack_repo/lihpc/meshing_supersede"
 
   spack-spec-mgx3d:

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -19,13 +19,13 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           ignore: "E501,F405,F403"
-          path: "meshing"
+          path: "spack_repo/lihpc/meshing"
 
       - name: Flake8 on meshing_supersede
         uses: py-actions/flake8@v2
         with:
           ignore: "E501,F405,F403,W504"
-          path: "meshing_supersede"
+          path: "spack_repo/lihpc/meshing_supersede"
 
   spack-spec-mgx3d:
     # The CMake configure and build commands are platform agnostic and should work equally
@@ -47,10 +47,10 @@ jobs:
       - name: Initialize Spack environment
         shell: bash
         run: |
-          git clone --depth=1 -b v0.23.1 https://github.com/spack/spack.git ${{github.workspace}}/spack
+          git clone --depth=1 -b v1.1.1 https://github.com/spack/spack.git ${{github.workspace}}/spack
           source ${{github.workspace}}/spack/share/spack/setup-env.sh
-          spack repo add ${{github.workspace}}/meshing
-          spack repo add ${{github.workspace}}/meshing_supersede
+          spack repo add ${{github.workspace}}/spack_repo/lihpc/meshing
+          spack repo add ${{github.workspace}}/spack_repo/lihpc/meshing_supersede
 
       - name: Check Spack spec
         # We create a subdirectory that will stand as our working directory for all
@@ -81,8 +81,8 @@ jobs:
         shell: bash
         run: |
           source /spack/share/spack/setup-env.sh
-          spack repo add $GITHUB_WORKSPACE/meshing
-          spack repo add $GITHUB_WORKSPACE/meshing_supersede
+          spack repo add $GITHUB_WORKSPACE/spack_repo/lihpc/meshing
+          spack repo add $GITHUB_WORKSPACE/spack_repo/lihpc/meshing_supersede
 
       - name: Build and Install Magix3D
         shell: bash

--- a/build_spack.sh
+++ b/build_spack.sh
@@ -1,12 +1,12 @@
 #==========================================
 # First get a spack release
-git clone --depth=1 -b v0.23.1  https://github.com/spack/spack.git
+git clone --depth=1 -b v1.1.1  https://github.com/spack/spack.git
 #==========================================
 # can be mandatory if you have already used spack on your computer
 # delete the .spack directory in the home of the user 
 #==========================================
 # get our recipes
-git clone https://github.com/LIHPC-Computational-Geometry/spack_recipes.git
+spack repo add https://github.com/LIHPC-Computational-Geometry/spack_recipes.git ./spack_recipes
 #==========================================
 # modifying spack configuration
 #==========================================
@@ -20,12 +20,6 @@ git clone https://github.com/LIHPC-Computational-Geometry/spack_recipes.git
 
 # this is used to declare opengl as non buildable and use the system library 
 cp ./spack_recipes/config/packages.yaml ./spack/etc/spack/
-
-# to register our recipes; it assumes that spack_recipes and spack are located at
-# the same level. You can use the "spack repo add" commands instead of copying the repos.yaml file
-#spack repo add ./spack_recipes/meshing
-#spack repo add ./spack_recipes/meshing_supersede
-cp spack_recipes/config/repos.yaml spack/etc/spack/defaults/repos.yaml
 
 # Optionnal: the default tmpdir used to build is defined in spack/etc/spack/defaults/config.yaml
 # under the entry build_stage: $tempdir/$user/spack-stage

--- a/build_spack_gmds.sh
+++ b/build_spack_gmds.sh
@@ -1,15 +1,10 @@
 #==========================================
 # First get a spack release
-# On macos v0.22.5 or v0.23.1 should be chosen (because of the system's python-3.12 version ?)
-#git clone --depth=1 -b v0.22.5  https://github.com/spack/spack.git
- git clone --depth=1 -b v0.23.1  https://github.com/spack/spack.git
+git clone --depth=1 -b v1.1.1  https://github.com/spack/spack.git
 #==========================================
 # can be mandatory if you have already used spack on your computer
 # delete the .spack directory in the home of the user  in order to 
 # have a fresh start 
-#==========================================
-# get our recipes
-git clone https://github.com/LIHPC-Computational-Geometry/spack_recipes.git
 #==========================================
 # modifying spack configuration
 #==========================================
@@ -21,12 +16,6 @@ git clone https://github.com/LIHPC-Computational-Geometry/spack_recipes.git
 # - in spack version 0.20.3
 #sed -i 's#"{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"#"{name}"#g' spack/etc/spack/defaults/config.yaml
 
-# to register our recipes; it assumes that spack_recipes and spack are located at
-# the same level. You can use the "spack repo add" commands instead of copying the repos.yaml file
-#spack repo add ./spack_recipes/meshing
-#spack repo add ./spack_recipes/meshing_supersede
-cp spack_recipes/config/repos.yaml spack/etc/spack/defaults/repos.yaml
-
 # Optionnal: the default tmpdir used to build is defined in spack/etc/spack/defaults/config.yaml
 # under the entry build_stage: $tempdir/$user/spack-stage
 # Should one prefer to use a tmpfs or has limited disk space in the temporary dir (Qt's build directory can require up to 6Go on my setup)
@@ -36,6 +25,9 @@ cp spack_recipes/config/repos.yaml spack/etc/spack/defaults/repos.yaml
 # configure spack using spack commands; it modifies the .spack directory in the user home
 source spack/share/spack/setup-env.sh
 spack clean -a
+#==========================================
+# get our recipes
+spack repo add https://github.com/LIHPC-Computational-Geometry/spack_recipes.git ./spack_recipes
 
 # registering cmake
 spack external find cmake

--- a/dockerfiles/Dockerfile.spack-gmds
+++ b/dockerfiles/Dockerfile.spack-gmds
@@ -1,7 +1,7 @@
 #============== OS LAYER ==================
 FROM ubuntu:22.04
 #==========================================
-ARG SPACK_VERSION=0.23.1
+ARG SPACK_VERSION=1.1.1
 # METADATA OF THE IMAGE
 LABEL description="GMDS image built with spack" \
       version.ubuntu="22.04" \
@@ -28,13 +28,12 @@ RUN cp -r cmake-3.31.8-linux-x86_64/* /usr/
 #==========================================
 RUN pip install pytest
 #==========================================
-RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git &&\
-    sed -i 's#"{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"#"{name}"#g' spack/etc/spack/defaults/config.yaml
+RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git
 #==========================================
 RUN source ./spack/share/spack/setup-env.sh && \
-    git clone --depth=1 https://github.com/LIHPC-Computational-Geometry/spack_recipes.git &&\
-    spack repo add ./spack_recipes/meshing &&\
-    spack repo add ./spack_recipes/meshing_supersede &&\
+    spack config --scope site add config:install_tree:projections:all:'"{name}"' &&\
+    # spack repo add --scope site https://github.com/LIHPC-Computational-Geometry/spack_recipes.git ./spack_recipes &&\
+    spack config --scope site add "repos:{'lihpc':{'git':'https://github.com/LIHPC-Computational-Geometry/spack_recipes.git','branch':'package-api-v2.2-migration','destination':'/spack_recipes'}}" &&\
     spack config --scope site add 'packages:all:target:[x86_64]' &&\
     spack compiler find &&\
     spack external find cmake

--- a/dockerfiles/Dockerfile.spack-gmds
+++ b/dockerfiles/Dockerfile.spack-gmds
@@ -18,7 +18,7 @@ ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 #==========================================
 RUN apt update &&\
-    apt install -y build-essential cmake python3 python3-venv pip unzip zip curl git autoconf wget lcov &&\
+    apt install -y build-essential cmake python3 python3-venv pip unzip zip curl git autoconf wget gfortran lcov &&\
     apt clean &&\
     rm -rf /var/lib/apt/lists/*
 #==========================================

--- a/dockerfiles/Dockerfile.spack-gmds-macos
+++ b/dockerfiles/Dockerfile.spack-gmds-macos
@@ -1,7 +1,7 @@
 #============== OS LAYER ==================
 FROM sickcodes/docker-osx
 #==========================================
-ARG SPACK_VERSION=0.23.1
+ARG SPACK_VERSION=1.1.1
 # METADATA OF THE IMAGE
 LABEL description="GMDS image built with spack for macos" \
       version.spack=${SPACK_VERSION}
@@ -13,16 +13,14 @@ ARG SPACK_VERSION
 #==========================================
 SHELL ["/bin/bash", "-c"]
 #==========================================
-RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git &&\
-    sed -i 's#"{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"#"{name}"#g' spack/etc/spack/defaults/config.yaml
+RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git
 #==========================================
 RUN source ./spack/share/spack/setup-env.sh && \
-    git clone --depth=1 https://github.com/LIHPC-Computational-Geometry/spack_recipes.git &&\
-    spack repo add ./spack_recipes/meshing &&\
-    spack repo add ./spack_recipes/meshing_supersede &&\
+    spack config --scope site add config:install_tree:projections:all:'"{name}"' &&\
+    spack repo add --scope site https://github.com/LIHPC-Computational-Geometry/spack_recipes.git spack_recipes &&\
     spack config --scope site add 'packages:all:target:[x86_64]' &&\
-    spack compiler find &&\
-    spack external find cmake
+    spack compiler find --scope site &&\
+    spack external find --scope site cmake
 #==========================================
 RUN source ./spack/share/spack/setup-env.sh && \
     spack install --only dependencies gmds+kmds+blocking ^kokkos+openmp ^cgns~mpi

--- a/dockerfiles/Dockerfile.spack-magix3d
+++ b/dockerfiles/Dockerfile.spack-magix3d
@@ -3,7 +3,7 @@
 # Ubuntu 22.04 allows to execute glxgears in a docker container
 FROM ubuntu:24.04
 #==========================================
-ARG SPACK_VERSION=0.23.1
+ARG SPACK_VERSION=1.1.1
 # METADATA OF THE IMAGE
 LABEL description="Magix3d image built with spack" \
       version.ubuntu="24.04" \
@@ -37,13 +37,12 @@ RUN wget -O FirefoxSetup.tar.bz2 "https://download.mozilla.org/?product=firefox-
     rm FirefoxSetup.tar.bz2 &&\
     ln -s /opt/firefox/firefox /usr/bin/firefox
 #==========================================
-RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git &&\
-    git clone --depth=1 https://github.com/LIHPC-Computational-Geometry/spack_recipes.git &&\
-    cp /spack_recipes/config/packages.yaml /spack/etc/spack/
+RUN git clone --depth=1 -b v${SPACK_VERSION} https://github.com/spack/spack.git
 
 RUN source /spack/share/spack/setup-env.sh &&\
-    spack repo add ./spack_recipes/meshing &&\
-    spack repo add ./spack_recipes/meshing_supersede &&\
+    # spack repo add https://github.com/LIHPC-Computational-Geometry/spack_recipes.git ./spack_recipes &&\
+    spack config --scope site add "repos:{'lihpc':{'git':'https://github.com/LIHPC-Computational-Geometry/spack_recipes.git','branch':'package-api-v2.2-migration','destination':'/spack_recipes'}}" &&\
+    spack config --scope site add --file /spack_recipes/config/packages.yaml &&\
     spack config --scope site add 'packages:all:target:[x86_64]' &&\
     spack compiler find &&\
     spack external find cmake

--- a/spack-repo-index.yaml
+++ b/spack-repo-index.yaml
@@ -1,0 +1,5 @@
+repo_index:
+  paths:
+  - spack_repo/lihpc/meshing
+  - spack_repo/lihpc/meshing_supersede
+

--- a/spack_repo/lihpc/meshing/packages/gmds/package.py
+++ b/spack_repo/lihpc/meshing/packages/gmds/package.py
@@ -1,24 +1,9 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project Gmds
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install gmds
-#
-# You can edit this file again by typing:
-#
-#     spack edit gmds
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
+# CEA/DAM/DSSI, 2020
+##############################################################################
 
 from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage

--- a/spack_repo/lihpc/meshing/packages/gmds/package.py
+++ b/spack_repo/lihpc/meshing/packages/gmds/package.py
@@ -81,7 +81,7 @@ class Gmds(CMakePackage):
 
     depends_on("cgal", when="+blocking")
     depends_on("py-pybind11", when="+python")
-    depends_on("lima+mli2", when="+lima")
+    depends_on("lima", when="+lima")
 
     # testing dependencies
     depends_on("lcov")

--- a/spack_repo/lihpc/meshing/packages/gmds/package.py
+++ b/spack_repo/lihpc/meshing/packages/gmds/package.py
@@ -1,0 +1,101 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install gmds
+#
+# You can edit this file again by typing:
+#
+#     spack edit gmds
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Gmds(CMakePackage):
+    """GMDS: Generic Mesh Data and Services."""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/gmds"
+    url = "https://github.com/LIHPC-Computational-Geometry/gmds/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/gmds.git"
+
+    version("main", branch="main")
+    version("1.4.6", sha256="04359b9cbdfac53e442b61db3282876b39ed1aca08ff6c31a3b57288a8048d04")
+    version("1.4.5", sha256="86a1408170ec23c190aec8ee35d500fd57c28251c894e956749011665466e863")
+    version("1.4.4", sha256="c85c53d14e5e3e4ba81202688fd9a7c917a8c9a422c4d690697963d77579c886")
+    version("1.4.3", sha256="0eca3433084b784024502b5bfbc047184b7ed91716b5a2896279ab3b8ca3fb26")
+    version("1.4.2", sha256="ed2a0aa682728b6b2f2e595d2e1388f98f85595d2772ac00761f8fddb127da19")
+    version("1.4.1", sha256="fda3eed76c05d3893ce2f5a6080315e3ed62daa43c0aac8b9c7d8e1338a5237f")
+    version("1.4.0", sha256="bf1b11ee4e50f199babb83ddcaa41ab6b21d5db1bbac2d1f892791f303578fa7")
+    version("1.3.9", sha256="b3aff5062559beb52d885bcec3bfe1f473c99963751d2545dbf55232cfa589e1")
+    version("1.3.8", sha256="4856ea2dac23f19e7b5cbe16c64cbc8083e3a2da14bcb12644f33bef28faa76a")
+    version("1.3.7", sha256="102a1370257a22c7a864629507113fecb91c68f63eafb12f95dd7fd44a2f992a")
+    version("1.3.6", sha256="135282c214c9a4f2c7fd1281001b026b7a35e260acb58093df1cc2907e159304")
+    version("1.3.5", sha256="9391e4f6858080fe38538fa7ad3650a1237a1db5fd4c165de6b1f62c1e0a1a74")
+    version("1.3.4", sha256="1d8c28e948eb26d20cac63e1884d4bac032ee74f1a5dfa70b532e847f48b9bb0")
+    version("1.3.3", sha256="a8387dfb4e023877a271dd862aa2a6ec301623daccc4aef1455861368e90daea")
+    version("1.3.2", sha256="cd6efea3815f0bf62951caa065e568405d938370547152a892ef28c921a99cc9")
+    version("1.3.1", sha256="59e5f993b8a650d67c3d317c27151cb784084f841606934ebc235cb4c886b215")
+    version("1.3.0", sha256="a21ae0d8941e91c37d7a255cb3b639823d33a0111f1a0a321adec58a027d7723")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    variant("kmds", default=False, description="Build with Kokkos")
+    variant("elg3d", default=False, description="Build Elg3D")
+    variant("blocking", default=False, description="Build the blocking component")
+    variant("lima", default=False, description="Provide Lima IO")
+    variant("python", default=False, description="Provide GMDS Python API")
+    variant("cgns", default=False, description="Provide CGNS blocking export")
+
+    depends_on("glpk")
+    # necessary to build the internal glpk
+    depends_on("libtool", type="build")
+    depends_on("eigen")
+
+    depends_on("kokkos", when="+kmds")
+
+    # necessary to find gts
+    depends_on("pkgconfig", type=("build"))
+    depends_on("pcre2")
+    depends_on("glib")
+    depends_on("gts")
+
+    depends_on("exodusii", when="+elg3d")
+
+    depends_on("cgns", when="+cgns")
+
+    conflicts("+elg3d", when="~kmds", msg="elg3d cannot be built without kmds.")
+
+    depends_on("cgal", when="+blocking")
+    depends_on("py-pybind11", when="+python")
+    depends_on("lima+mli2", when="+lima")
+
+    # testing dependencies
+    depends_on("lcov")
+    depends_on("googletest")
+    depends_on("py-pytest", when="+python")
+
+    depends_on("nlohmann-json")
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("ENABLE_KMDS", "kmds"))
+        args.append(self.define_from_variant("ENABLE_ELG3D", "elg3d"))
+        args.append(self.define_from_variant("ENABLE_BLOCKING", "blocking"))
+        args.append(self.define_from_variant("WITH_PYTHON_API", "python"))
+        args.append(self.define_from_variant("WITH_LIMA", "lima"))
+        args.append(self.define_from_variant("WITH_CGNS", "cgns"))
+        return args

--- a/spack_repo/lihpc/meshing/packages/gmds/package.py
+++ b/spack_repo/lihpc/meshing/packages/gmds/package.py
@@ -5,8 +5,9 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Gmds(CMakePackage):

--- a/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
+++ b/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
@@ -8,6 +8,7 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 
 class Guitoolkitsvariables(CMakePackage):
+    """Common cmake files used by projects of the magix3d ecosystem."""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/guitoolkitsvariables"
     url = ("https://github.com/LIHPC-Computational-Geometry/"

--- a/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
+++ b/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
@@ -3,16 +3,19 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Guitoolkitsvariables(CMakePackage):
     """Common cmake files used by projects of the magix3d ecosystem."""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/guitoolkitsvariables"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "guitoolkitsvariables/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "guitoolkitsvariables/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/guitoolkitsvariables.git"
     maintainers = ["meshing_team"]
 

--- a/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
+++ b/spack_repo/lihpc/meshing/packages/guitoolkitsvariables/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Guitoolkitsvariables(CMakePackage):
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/guitoolkitsvariables"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "guitoolkitsvariables/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/guitoolkitsvariables.git"
+    maintainers = ["meshing_team"]
+
+    version("main", branch="main")
+    version("1.6.0", sha256="a3c218b46dc37ca72f05399cc8f94f71f23c5ed0b26fc27541cd830cc2201818")
+    version("1.5.3", sha256="485706d072f222e232811357e1ac3eff42fe08f32e8a4b996e7d92c3023c0756")
+    version("1.5.2", sha256="e0be5879b87fc9661c0f66ed3d2cd188a5769c75ea63a280a7b3c1067824c6e0")
+    version("1.5.1", sha256="fc6aa63fef7cc3b6a74d2aa79a97f83a01defa45b80fa307f0e49fc65a241938")
+    version("1.5.0", sha256="7bbd606571634d971e645ab76613bf1bcde7d1193ab6ab10b7e3f8540640723e")
+    version("1.4.3", sha256="d3455e90300eea95522d30a14a24f8f0053663e8761606ea4c91b7aa934f86e4")
+    version("1.4.2", sha256="564d3d55a274faedf9d8c3b1f351f7268d2e40e58dc6a92745c53c67c45a764e")
+    version("1.4.1", sha256="9670a0f383aa70b3005c85bf2e48b1b843084be172d150efc5268ab5c8dfdf1d")
+    version("1.3.3", sha256="8b0cfa94d892af453bb2f6672a2f4ffcc8129ec20ae045a8f6f4e13c2b4a96de")
+    version("1.3.2", sha256="3e8621469763e3216c4cea9197eba3361fb1cd4e060f0295a65e99e9262250f4")
+    version("1.3.0", sha256="bc8844a6b13b35eea8cb99676e23824d6e437f7cfe3bc7aedea62a7b3e93bb64")
+
+    def cmake_args(self):
+        args = []
+        return args

--- a/spack_repo/lihpc/meshing/packages/lima/cmake-7.6.0.patch
+++ b/spack_repo/lihpc/meshing/packages/lima/cmake-7.6.0.patch
@@ -1,0 +1,11 @@
+diff -ur lima-ref/src/Lima/cmake/LimaConfig.cmake.in lima/src/Lima/cmake/LimaConfig.cmake.in
+--- lima-ref/src/Lima/cmake/LimaConfig.cmake.in	2020-10-12 14:08:26.888478742 +0200
++++ lima/src/Lima/cmake/LimaConfig.cmake.in	2020-10-12 14:21:13.117411669 +0200
+@@ -5,6 +5,7 @@
+ include(CMakeFindDependencyMacro)
+ include (${CMAKE_CURRENT_LIST_DIR}/FindHdf145.cmake)
+ find_dependency (HDF5)
++find_dependency (Threads)
+ 
+ # EXPURGE_BEGINNING_TAG LOCAL_DEPENDENCIES
+ set (MachineTypes_FOUND "@MachineTypes_ENABLED@")

--- a/spack_repo/lihpc/meshing/packages/lima/cmake.patch
+++ b/spack_repo/lihpc/meshing/packages/lima/cmake.patch
@@ -1,0 +1,39 @@
+diff -ur lima-ori/src/Lima/cmake/LimaConfig.cmake.in lima/src/Lima/cmake/LimaConfig.cmake.in
+--- lima-ori/src/Lima/cmake/LimaConfig.cmake.in	2020-07-20 14:49:37.458912937 +0200
++++ lima/src/Lima/cmake/LimaConfig.cmake.in	2020-07-20 15:02:36.627495976 +0200
+@@ -1,20 +1,27 @@
+ @PACKAGE_INIT@
++
++# First, because depends on PACKAGE_PREFIX_DIR,
++# which can be changed by following calls to find_package
++
++# Ugly code :
++set (Lima_VERSION @LIMA_VERSION@)
++# Is this still useful ?
++set_and_check (Lima_INCLUDE_DIR   "@PACKAGE_INCLUDE_INSTALL_DIR@")
++set_and_check (Lima_LIB_DIR   "@PACKAGE_LIB_INSTALL_DIR@")
++
+ include(CMakeFindDependencyMacro)
+ include (${CMAKE_CURRENT_LIST_DIR}/FindHdf145.cmake)
+-include (FindHDF5)
+-include (FindZLIB)
+-include (FindThreads)
++
++find_dependency (HDF5 REQUIRED)
++find_dependency (ZLIB REQUIRED)
++find_dependency (Threads REQUIRED)
+ # EXPURGE_BEGINNING_TAG LOCAL_DEPENDENCIES
+ find_dependency (Sumesh REQUIRED)
+ find_dependency (MachineTypes REQUIRED)
+ # EXPURGE_COMPLETION_TAG
+ 
+-# Ugly code :
+-set (Lima_VERSION @LIMA_VERSION@)
+-set_and_check (Lima_INCLUDE_DIR   "@PACKAGE_INCLUDE_INSTALL_DIR@")
+-set_and_check (Lima_LIB_DIR   "@PACKAGE_LIB_INSTALL_DIR@")
+ check_required_components (Lima)
+ 
+-# Fournir l'accès aux services des cibles (fichier non inclus automatiquement) :
++# Lima targets
+ include(${CMAKE_CURRENT_LIST_DIR}/LimaTargets.cmake)
+ 

--- a/spack_repo/lihpc/meshing/packages/lima/package.py
+++ b/spack_repo/lihpc/meshing/packages/lima/package.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# From version 7.11.0 writing support for the mli format is no longer provided.
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Lima(CMakePackage):
+    """Logiciel Interface MAillage"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/lima"
+    url = "https://github.com/LIHPC-Computational-Geometry/lima/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/lima.git"
+    maintainers = ["meshing_team"]
+
+    extends("python", when="+scripting")  # For the PYTHONPATH in the generated modules
+
+    depends_on("machine-types", when="+machinetypes")
+    depends_on("swig", type=("build"), when="+scripting")
+    depends_on("python +shared", type=("build", "link"), when="+scripting")
+    depends_on("hdf5 +shared +cxx", type=("build", "link"), when="+mli2")
+    depends_on("c", type=("build"))
+    depends_on("cxx", type=("build"))
+    depends_on("fortran", type=("build"))
+
+    variant("scripting", default=False, description="Build python binding")
+    variant("shared", default=True, description="Build shared library")
+    variant(
+        "xlmlima",
+        default=True,
+        description="Build xlmlima tool (converts and prepares meshes for non-regression tests)"
+    )
+    variant(
+        "mli2",
+        default=True,
+        description="Build Lima with mli2 format support (requires HDF5 >=1.10.0)"
+    )
+    variant(
+        "machinetypes",
+        default=True,
+        description="Build Lima MachineTypes API (shareable numeric types definitions)"
+    )
+    variant("i4", default=False, description="int_type=int32 instead of int64")
+    variant("r4", default=False, description="real=float instead of double")
+    variant(
+        "tests",
+        default=True,
+        description="Builds the mesh comparison tool (necessary for non-regression tests)"
+    )
+    # disable_mli_warning=True for non regression testing,
+    # false otherwise (blue warning message when obsolete mli format is used)
+    variant(
+        "disable_mli_warning",
+        default=False,
+        description="Disables warning messages displayed when reading or writing an mli file"
+    )
+
+    patch("cmake.patch", when="@7.4.3")
+    patch("cmake-7.6.0.patch", when="@7.6.0")
+
+    version("main", branch="main")
+    version("7.12.2", sha256="8308c68d7c18b387b47bc969d472233eb2fdf00a5fc56bc081c9579374a78f04")
+    version("7.12.1", sha256="4c919e640b4f4fcef7d1c6c1e1e72a8d16762dd63cd691f9226a185cb6270c3f")
+    version("7.12.0", sha256="437c5ddf8b8994a01977bf5656b8f9457b0548a4a2f96c335e046dd485381274")
+    version("7.11.2", sha256="87105227d07484feb5a4cf8aef75734165abd478f205e3723a2573ef4ef904aa")
+    version("7.11.1", sha256="a1b0397ce668cb473775fd1f5e2adc30880680042b623e63e9a6b855ecf03591")
+    version("7.11.0", sha256="9fcce72a37e1e3f71745482d17c357739a094fd31283fde7f79d898f2922230d")
+    version("7.10.3", sha256="ccd943aeeee3cf28e9e12a5596b94adfe7d63bb8514858556481494fd8b2cdcd")
+    version("7.10.2", sha256="60975df285defe7f8aee8f5858b4ab2c917053279db4b4b2adab7ce25f1aeb9c")
+    version("7.10.1", sha256="27480c4df5ddba0738f5f916cf3c53b054feeae78d14cc669bb633ba745f4ca0")
+    version("7.10.0", sha256="95d6d0f3d696945fd88a70572eb3ec769f484e2315017566f3b971f9048632bb")
+    version("7.9.6", sha256="650f071afb420cab80cfb4f25913b59f2cff68f6ceb921ea91f58d6985460cba")
+    version("7.9.5", sha256="48d06f71cefb7253d24b4ae5f9803219ab861281806521d97f335d6a2a209ccd")
+    version("7.9.4", sha256="ab2fae0938b08c86685b0b2809dff5f6f69bb139e50179c952b391447d5833ec")
+    version("7.9.3", sha256="4ef65333269ad9ba3a522a4b82d621b4a9ae6d920042a67361fe0a404c4fd0c1")
+    version("7.9.2", sha256="fee1d16d12b6b2beaa6680903f67feba0fe10a0b1159a61dd926816f89e635fa")
+    version("7.9.1", sha256="da517fa87a6df3b07e793d8a6a300865614803fa84cf1d3ec1994605e69b4571")
+    version("7.9.0", sha256="7849219cf1de94c63fe019187a4a8dec61447d1b726fac90f43d871293f55315")
+    version("7.8.1", sha256="a54de52e7414d820c5ba081cf6693e753e92993f0d250f56fd215cc2fbe28b65")
+    version("7.7.9", sha256="e251a6732a2cdafb7f2851be3c5f5dba41d937fe253a9ebbf50fb81a7ddbd11f")
+    version("7.4.2", sha256="7bbcd876f8c6c4330583e281707777f3142d469c248c0b0e0c6dcbda6621e8d0")
+    version("7.5.1", sha256="91ef19f6f48d6795a776fea4ceabfc6e19f21f9dbb7dd489191f0ef9ff5c040a")
+    version("7.6.0", sha256="6c8c963c487430de1f00bba0cd7fe1a6ec5f2ee07d1b465b74f29d71fb45fe48")
+    version("7.6.3", sha256="4039ebbf3f7e047b6cb75393c6a3d4a86be635c03798bb2eb69760c2b760a508")
+
+    conflicts("~shared", "+scripting")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("BUILD_SCRIPTING", "scripting"),
+            self.define_from_variant("BUILD_XLMLIMA", "xlmlima"),
+            self.define_from_variant("BUILD_TESTS", "tests"),
+            self.define_from_variant("DISABLE_MLI_WARNING", "disable_mli_warning"),
+            self.define_from_variant("FORMAT_MLI2", "mli2"),
+            self.define_from_variant("MACHINE_TYPES", "machinetypes")
+        ]
+
+        args.append(self.define("MACHINE_TYPES", False))
+        args.append(self.define("FORMAT_MLI", False))
+        args.append(self.define("SUMESH", False))
+
+        if "+i4" in self.spec:
+            args.append(self.define("INT_8", False))
+        else:
+            args.append(self.define("INT_8", True))
+
+        if "+r4" in self.spec:
+            args.append(self.define("REAL_8", False))
+        else:
+            args.append(self.define("REAL_8", True))
+
+        if "+scripting" in self.spec:
+            py = self.spec["python"]
+            args.extend(
+                [
+                    # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+                    self.define("Python_EXECUTABLE", py.command.path),
+                    # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+                    self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path)
+                ]
+            )
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/lima/package.py
+++ b/spack_repo/lihpc/meshing/packages/lima/package.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # From version 7.11.0 writing support for the mli format is no longer provided.
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Lima(CMakePackage):
@@ -28,31 +29,31 @@ class Lima(CMakePackage):
     variant(
         "xlmlima",
         default=True,
-        description="Build xlmlima tool (converts and prepares meshes for non-regression tests)"
+        description="Build xlmlima tool (converts and prepares meshes for non-regression tests)",
     )
     variant(
         "mli2",
         default=True,
-        description="Build Lima with mli2 format support (requires HDF5 >=1.10.0)"
+        description="Build Lima with mli2 format support (requires HDF5 >=1.10.0)",
     )
     variant(
         "machinetypes",
         default=True,
-        description="Build Lima MachineTypes API (shareable numeric types definitions)"
+        description="Build Lima MachineTypes API (shareable numeric types definitions)",
     )
     variant("i4", default=False, description="int_type=int32 instead of int64")
     variant("r4", default=False, description="real=float instead of double")
     variant(
         "tests",
         default=True,
-        description="Builds the mesh comparison tool (necessary for non-regression tests)"
+        description="Builds the mesh comparison tool (necessary for non-regression tests)",
     )
     # disable_mli_warning=True for non regression testing,
     # false otherwise (blue warning message when obsolete mli format is used)
     variant(
         "disable_mli_warning",
         default=False,
-        description="Disables warning messages displayed when reading or writing an mli file"
+        description="Disables warning messages displayed when reading or writing an mli file",
     )
 
     patch("cmake.patch", when="@7.4.3")
@@ -93,7 +94,7 @@ class Lima(CMakePackage):
             self.define_from_variant("BUILD_TESTS", "tests"),
             self.define_from_variant("DISABLE_MLI_WARNING", "disable_mli_warning"),
             self.define_from_variant("FORMAT_MLI2", "mli2"),
-            self.define_from_variant("MACHINE_TYPES", "machinetypes")
+            self.define_from_variant("MACHINE_TYPES", "machinetypes"),
         ]
 
         args.append(self.define("MACHINE_TYPES", False))
@@ -117,7 +118,7 @@ class Lima(CMakePackage):
                     # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
                     self.define("Python_EXECUTABLE", py.command.path),
                     # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
-                    self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path)
+                    self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
                 ]
             )
 

--- a/spack_repo/lihpc/meshing/packages/machine_types/package.py
+++ b/spack_repo/lihpc/meshing/packages/machine_types/package.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project machine-types
+#
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class MachineTypes(CMakePackage):
+    """Simple C numeric types definitions"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/machine-types"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "machine-types/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/machine-types.git"
+
+    version("2.0.1", sha256="c961e25f883cf1f48f3cbace1d4263292014f5fe863854f7094f745792e94a9c")
+    version("2.0.0", sha256="fb7d0095b2b4028e1cead97363c3e6c0bdaaa582ae6e90cd7f70cb8e344a730e")

--- a/spack_repo/lihpc/meshing/packages/machine_types/package.py
+++ b/spack_repo/lihpc/meshing/packages/machine_types/package.py
@@ -4,16 +4,19 @@
 #
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class MachineTypes(CMakePackage):
     """Simple C numeric types definitions"""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/machine-types"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "machine-types/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "machine-types/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/machine-types.git"
 
     version("2.0.1", sha256="c961e25f883cf1f48f3cbace1d4263292014f5fe863854f7094f745792e94a9c")

--- a/spack_repo/lihpc/meshing/packages/magix3d/package.py
+++ b/spack_repo/lihpc/meshing/packages/magix3d/package.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from spack.package import *
 import os
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Magix3d(CMakePackage):
@@ -18,9 +20,9 @@ class Magix3d(CMakePackage):
     variant("sepa3d", default=False, description="Outil de separatrices 3D")
     variant("smooth3d", default=False, description="Bibliotheque de lissage volumique Smooth3D")
     variant("triton2", default=True, description="Mailleur tetraedrique Tetgen")
-    variant("pythonaddon",
-            default=False,
-            description="Additional python modules to enrich PYTHONPATH")
+    variant(
+        "pythonaddon", default=False, description="Additional python modules to enrich PYTHONPATH"
+    )
     variant("doc", default=False, description="Installation de la documentation utilisateur")
 
     version("2.7.0", sha256="362ac988f8d00e504d7a32f0dbc8e347a9625c344cc06aa24074ff4173442c8b")
@@ -100,7 +102,7 @@ class Magix3d(CMakePackage):
 
     # setup PYTHON_PATH for documentation
     def setup_build_environment(self, env):
-        if ("+doc" in self.spec.variants):
+        if "+doc" in self.spec.variants:
             python_version = str(self.spec["python"].version).split(".")
             python_dir = "python" + python_version[0] + "." + python_version[1]
 
@@ -109,8 +111,9 @@ class Magix3d(CMakePackage):
             env.prepend_path("PYTHONPATH", sphinx_pythonpath)
 
     def cmake_args(self):
-        return self.fill_cmake_args(False, "undefined", "undefined",
-                                    "undefined", "unavailable", "undefined", "undefined")
+        return self.fill_cmake_args(
+            False, "undefined", "undefined", "undefined", "unavailable", "undefined", "undefined"
+        )
 
     def fill_cmake_args(self, batch, t_ext, erd_ext, team, dkoc_lic, url_wiki, url_doc_qualif):
         args = []
@@ -120,7 +123,7 @@ class Magix3d(CMakePackage):
         # On installe => mode production pour les scripts fixant l"environnement python d"execution
         args.append("-DPRODUCTION:BOOL=ON")
         if self.spec.satisfies("%intel"):
-            args.append("-DCMAKE_CXX_FLAGS=\"-std=c++11\"")
+            args.append('-DCMAKE_CXX_FLAGS="-std=c++11"')
 
         args.append(self.define_from_variant("DKOC", "dkoc"))
         args.append(self.define_from_variant("MDLPARSER", "mdlparser"))
@@ -140,23 +143,38 @@ class Magix3d(CMakePackage):
         args.append(self.define("BUILD_MAGIX3D", True))
         args.append(self.define("BUILD_MAGIX3DBATCH", batch))
 
-        if ("+doc" in self.spec.variants):
+        if "+doc" in self.spec.variants:
             args.append("-DSPHINX_WARNINGS_AS_ERRORS=OFF")
 
         # only py-numpy py-matplotlib py-scipy are necessary
         # the rest are here because we are not in an environment
         if "+pythonaddon" in self.spec:
             python_version = self.spec["python"].version.up_to(2)
-            py_depends = ["py-numpy", "py-matplotlib", "py-scipy",
-                          "py-cycler", "py-kiwisolver",
-                          "py-pillow", "py-pyparsing", "py-python-dateutil",
-                          "py-pytz", "py-setuptools", "py-setuptools-scm",
-                          "py-six", "py-packaging"]
+            py_depends = [
+                "py-numpy",
+                "py-matplotlib",
+                "py-scipy",
+                "py-cycler",
+                "py-kiwisolver",
+                "py-pillow",
+                "py-pyparsing",
+                "py-python-dateutil",
+                "py-pytz",
+                "py-setuptools",
+                "py-setuptools-scm",
+                "py-six",
+                "py-packaging",
+            ]
             python_path = []
             for py_dep in py_depends:
-                python_path.append(os.path.join(self.spec[py_dep].prefix, "lib",
-                                                "python" + str(python_version),
-                                                "site-packages"))
+                python_path.append(
+                    os.path.join(
+                        self.spec[py_dep].prefix,
+                        "lib",
+                        "python" + str(python_version),
+                        "site-packages",
+                    )
+                )
             args.append("-DADDPYTHONPACKAGES=" + ":".join(python_path) + ":")
 
         return args

--- a/spack_repo/lihpc/meshing/packages/magix3d/package.py
+++ b/spack_repo/lihpc/meshing/packages/magix3d/package.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+from spack.package import *
+import os
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Magix3d(CMakePackage):
+    """Mailleur 3D"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/magix3d"
+    url = "https://github.com/LIHPC-Computational-Geometry/magix3d/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/magix3d.git"
+    maintainers = ["meshing_team"]
+
+    variant("dkoc", default=False, description="Lecteur Catia pour OpenCascade")
+    variant("mdlparser", default=False, description="Lecteur du format mdl")
+    variant("sepa3d", default=False, description="Outil de separatrices 3D")
+    variant("smooth3d", default=False, description="Bibliotheque de lissage volumique Smooth3D")
+    variant("triton2", default=True, description="Mailleur tetraedrique Tetgen")
+    variant("pythonaddon",
+            default=False,
+            description="Additional python modules to enrich PYTHONPATH")
+    variant("doc", default=False, description="Installation de la documentation utilisateur")
+
+    version("2.7.0", sha256="362ac988f8d00e504d7a32f0dbc8e347a9625c344cc06aa24074ff4173442c8b")
+    version("2.6.3", sha256="b875c0e08b9f3779322338bb436b1865ee453d5c77a5ea27300a87cf03d1d757")
+    version("2.6.2", sha256="51f15612423f795b5983e893e0c527ae2a82254e0a7beef189959caca6931457")
+    version("2.6.1", sha256="3a679d56b332691f2cf0e0ff609e8f67596b4badf7db1f9e1a464bfc4a2c889d")
+    version("2.6.0", sha256="ea1aac98f9f32c83b04af027609f424dbc31a6a92e3c1b023478d3344c2b8dae")
+    version("2.5.2", sha256="1bfd56620ec2b91c4c677efbc1da8f56f6de1bb7a05a8383cd04b6cc04654a37")
+    version("2.5.1", sha256="274ebfd5f3d8f4bfa9cac1f36c297f60c88198dbd56cf724d6aa93429072b1cb")
+    version("2.5.0", sha256="b3dfed9dadef3f3ef80219d7d7f9a8c54f2d979efc1e83877c8c59df8e25a56b")
+    version("2.4.2", sha256="7a81bea88a85dea0e30c311053807449f354a5c7859af9c099b8da2c8af23113")
+    version("2.4.1", sha256="07934ea3d7a3ff99a8c6e8a7419e6b1f7311d430de4bcb8a7b089376b581adb1")
+    version("2.4.0", sha256="c2b0644355025f35f6dda29fe14ab72e0375f0aef67cd300d89b8050dd698232")
+    version("2.3.5", sha256="28808a4c5893f84e2de43c8913c6609f97b1a6b213b3bb2d7dd37a8a6c8f8d39")
+    version("2.3.4", sha256="934475f0738f7f6d48eb3e33336b4ce6625811722aebc5a566b7327d9dbdd255")
+    version("2.3.3", sha256="fd1fbbde688dcfd2ab5e7f102d3209c0e1da7c8bdc8cb0691a5701f9c382f4de")
+    version("2.3.2", sha256="5ae3afda57218c0dd6dea8373256f353112ae9156bbef2dd84666b6e32e65b74")
+    version("2.3.1", sha256="07f6cabd231777273468dc806f0c318b4520831dbcaf1fa2906c39051585410a")
+    version("2.3.0", sha256="9949dac2aa3df14f0e96e94105f47d0a612a83524c8138171fb1860a00feaf36")
+    version("2.2.7", sha256="4437209e1811b523c3945fda17ab6aaf2082da9c84f892955123e69465ebd250")
+    version("2.2.6", sha256="9d39dd74a1b9360a5ca2790f2d9e8b17429f82833df2d633b57c866383873d05")
+    version("2.2.5")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("tkutil")
+    depends_on("vtkcontrib@4: +shared", type=("build", "link"))
+    depends_on("preferences@5: +shared", type=("build", "link"))
+    depends_on("pythonutil@5: +shared", type=("build", "link"))
+    depends_on("qqualif+gmds", type=("build", "link"))
+    depends_on("qtpython@4: +shared", type=("build", "link"))
+    depends_on("qtvtk@7: +shared", type=("build", "link"))
+    depends_on("cgns", type=("build", "link"))
+    depends_on("gmds+lima+cgns", type=("build", "link"))
+    depends_on("gts", type=("build", "link"))
+    depends_on("opencascade@7.8.1+data_exchange", type=("build", "link"))
+    depends_on("tetgen@1.6.0", when="+triton2")
+    depends_on("smooth3d +shared", type=("build", "link"), when="+smooth3d")
+    depends_on("swig", type="build")
+    depends_on("mesquite")
+    depends_on("python")
+    depends_on("qt")
+    depends_on("doxygen", type=("build"))
+    depends_on("lima@7.12.1: +scripting")
+    depends_on("pkgconfig", type=("build"))
+    depends_on("nlohmann-json")
+    depends_on("gmsh ~mmg~fltk+opencascade")
+
+    # depends_on("mdl-parser@1.5.2: +shared", type=("build", "link"), when="+mdlparser")
+    # depends_on("dkoc", type=("build", "link"), when="+dkoc")
+    # depends_on("separatrice3d +shared", type=("build", "link"), when="+sepa3d")
+    # depends_on("experimentalroom")
+
+    depends_on("py-numpy", when="+pythonaddon")
+    depends_on("py-matplotlib", when="+pythonaddon")
+    depends_on("py-scipy", when="+pythonaddon")
+    depends_on("py-cycler", when="+pythonaddon")
+    depends_on("py-kiwisolver", when="+pythonaddon")
+    depends_on("py-pillow", when="+pythonaddon")
+    depends_on("py-pyparsing", when="+pythonaddon")
+    depends_on("py-python-dateutil", when="+pythonaddon")
+    depends_on("py-pytz", when="+pythonaddon")
+    depends_on("py-setuptools", when="+pythonaddon")
+    depends_on("py-setuptools-scm", when="+pythonaddon")
+    depends_on("py-six", when="+pythonaddon")
+    depends_on("py-packaging", when="+pythonaddon")
+
+    # documentation
+    depends_on("py-breathe", when="+doc")
+    depends_on("py-rst2pdf", when="+doc")
+    # sphinx version fixed for rtd_theme
+    depends_on("py-sphinx@5.3.0", when="+doc")
+    # rtd_theme version fixed to fix no module found epub3
+    depends_on("py-sphinx-rtd-theme@0.5.1", when="+doc")
+    depends_on("py-sphinx-copybutton", when="+doc")
+
+    # setup PYTHON_PATH for documentation
+    def setup_build_environment(self, env):
+        if ("+doc" in self.spec.variants):
+            python_version = str(self.spec["python"].version).split(".")
+            python_dir = "python" + python_version[0] + "." + python_version[1]
+
+            sphinx_path = self.spec["py-sphinx"].prefix
+            sphinx_pythonpath = join_path(sphinx_path, "lib", python_dir, "site-packages")
+            env.prepend_path("PYTHONPATH", sphinx_pythonpath)
+
+    def cmake_args(self):
+        return self.fill_cmake_args(False, "undefined", "undefined",
+                                    "undefined", "unavailable", "undefined", "undefined")
+
+    def fill_cmake_args(self, batch, t_ext, erd_ext, team, dkoc_lic, url_wiki, url_doc_qualif):
+        args = []
+
+        # Toujours en mode shared, pour le scripting
+        args.append("-DBUILD_SHARED_LIBS:BOOL=ON")
+        # On installe => mode production pour les scripts fixant l"environnement python d"execution
+        args.append("-DPRODUCTION:BOOL=ON")
+        if self.spec.satisfies("%intel"):
+            args.append("-DCMAKE_CXX_FLAGS=\"-std=c++11\"")
+
+        args.append(self.define_from_variant("DKOC", "dkoc"))
+        args.append(self.define_from_variant("MDLPARSER", "mdlparser"))
+        args.append(self.define_from_variant("SEPA3D", "sepa3d"))
+        args.append(self.define_from_variant("SMOOTH3D", "smooth3d"))
+        args.append(self.define_from_variant("TRITON", "triton2"))
+        args.append(self.define_from_variant("PYTHONADDON", "pythonaddon"))
+        args.append(self.define_from_variant("WITH_DOC", "doc"))
+
+        args.append(self.define("T_INTERNAL_EXTENSION", t_ext))
+        args.append(self.define("ERD_INTERNAL_EXTENSION", erd_ext))
+        args.append(self.define("USER_TEAM", team))
+        args.append(self.define("DKOC_LICENCE", dkoc_lic))
+        args.append(self.define("URL_WIKI", url_wiki))
+        args.append(self.define("URL_QUALIF", url_doc_qualif))
+
+        args.append(self.define("BUILD_MAGIX3D", True))
+        args.append(self.define("BUILD_MAGIX3DBATCH", batch))
+
+        if ("+doc" in self.spec.variants):
+            args.append("-DSPHINX_WARNINGS_AS_ERRORS=OFF")
+
+        # only py-numpy py-matplotlib py-scipy are necessary
+        # the rest are here because we are not in an environment
+        if "+pythonaddon" in self.spec:
+            python_version = self.spec["python"].version.up_to(2)
+            py_depends = ["py-numpy", "py-matplotlib", "py-scipy",
+                          "py-cycler", "py-kiwisolver",
+                          "py-pillow", "py-pyparsing", "py-python-dateutil",
+                          "py-pytz", "py-setuptools", "py-setuptools-scm",
+                          "py-six", "py-packaging"]
+            python_path = []
+            for py_dep in py_depends:
+                python_path.append(os.path.join(self.spec[py_dep].prefix, "lib",
+                                                "python" + str(python_version),
+                                                "site-packages"))
+            args.append("-DADDPYTHONPACKAGES=" + ":".join(python_path) + ":")
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/preferences/package.py
+++ b/spack_repo/lihpc/meshing/packages/preferences/package.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project Preferences
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Preferences(CMakePackage):
+    """Bibliotheque d'utilitaires de preferences utilisateur reposant sur XercesC et Qt"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/preferences"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "preferences/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/preferences.git"
+
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("qtutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("qtutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("tkutil")
+    depends_on("xerces-c", type=("build", "link"))
+    depends_on("qt")
+    depends_on("pkgconfig", type=("build"))
+
+    version("6.3.1", sha256="ecc5fa932d1e7b33d97d9e032a32c17b28e287893361228afc84235a55e1f2f9")
+    version("6.3.0", sha256="300742a5dce7055f340b461d6740e89599b5c64e74bc37aa2f8953cc28ea7f90")
+    version("6.2.2", sha256="5797fee3678c4b6d340a0cc4dd49fd2f050ed4574b9bba178d5c23aecadccc32")
+    version("6.2.1", sha256="b39a6db6cb01fb264ce206c4ad2dbc49b6e2b9ce56ecc23c27b562937f70edb6")
+    version("6.2.0", sha256="f7e7fe9ad7f7c5578e1bfbfd3318a04e15e6891459559f8d8971279701b0d458")
+    version("5.6.2", sha256="f734cc05483303b5e5168da55537e212037108360c0981ae3816d034ac3214fc")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("5.5.7",
+            sha256="09600a039e8458993eecaa8d7a6a8396f910caeddb3aecb4a7873d1cbaea31ae",
+            deprecated=True)
+    version("5.5.3",
+            sha256="9077607e1ed81d83ea675112f1be6e6d82b314a7756eef67da85cee9dad7642f",
+            deprecated=True)
+    version("5.5.2",
+            sha256="7f5544912c4b1044e398b5dc06ad21b5c918b461166ddc407e07396befb34137",
+            deprecated=True)
+    version("5.1.0",
+            sha256="8add5bcdd2ff0e70cfca49f00c4b848e771da4295143638e4978d0563050c0ed",
+            deprecated=True)
+    version("5.0.2",
+            sha256="2baa60b1d249c0af491a883f3fe4acd1d98a778136fef7713bbf69d83dc5c982",
+            deprecated=True)
+    version("5.0.0",
+            sha256="15a19af6009da3e9365684007cab7fa138d6040b01e365b0d2a8b2a0064d08e3",
+            deprecated=True)
+
+    depends_on("cxx", type="build")  # generated
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        if self.spec.satisfies("%intel"):
+            args.append("-DCMAKE_CXX_FLAGS=\"-std=c++11\"")
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/preferences/package.py
+++ b/spack_repo/lihpc/meshing/packages/preferences/package.py
@@ -5,16 +5,19 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Preferences(CMakePackage):
     """Bibliotheque d'utilitaires de preferences utilisateur reposant sur XercesC et Qt"""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/preferences"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "preferences/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "preferences/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/preferences.git"
 
     maintainers = ["meshing_team"]
@@ -34,24 +37,36 @@ class Preferences(CMakePackage):
     version("6.2.0", sha256="f7e7fe9ad7f7c5578e1bfbfd3318a04e15e6891459559f8d8971279701b0d458")
     version("5.6.2", sha256="f734cc05483303b5e5168da55537e212037108360c0981ae3816d034ac3214fc")
     # versions below are deprecated as sources are in the infinite void of space
-    version("5.5.7",
-            sha256="09600a039e8458993eecaa8d7a6a8396f910caeddb3aecb4a7873d1cbaea31ae",
-            deprecated=True)
-    version("5.5.3",
-            sha256="9077607e1ed81d83ea675112f1be6e6d82b314a7756eef67da85cee9dad7642f",
-            deprecated=True)
-    version("5.5.2",
-            sha256="7f5544912c4b1044e398b5dc06ad21b5c918b461166ddc407e07396befb34137",
-            deprecated=True)
-    version("5.1.0",
-            sha256="8add5bcdd2ff0e70cfca49f00c4b848e771da4295143638e4978d0563050c0ed",
-            deprecated=True)
-    version("5.0.2",
-            sha256="2baa60b1d249c0af491a883f3fe4acd1d98a778136fef7713bbf69d83dc5c982",
-            deprecated=True)
-    version("5.0.0",
-            sha256="15a19af6009da3e9365684007cab7fa138d6040b01e365b0d2a8b2a0064d08e3",
-            deprecated=True)
+    version(
+        "5.5.7",
+        sha256="09600a039e8458993eecaa8d7a6a8396f910caeddb3aecb4a7873d1cbaea31ae",
+        deprecated=True,
+    )
+    version(
+        "5.5.3",
+        sha256="9077607e1ed81d83ea675112f1be6e6d82b314a7756eef67da85cee9dad7642f",
+        deprecated=True,
+    )
+    version(
+        "5.5.2",
+        sha256="7f5544912c4b1044e398b5dc06ad21b5c918b461166ddc407e07396befb34137",
+        deprecated=True,
+    )
+    version(
+        "5.1.0",
+        sha256="8add5bcdd2ff0e70cfca49f00c4b848e771da4295143638e4978d0563050c0ed",
+        deprecated=True,
+    )
+    version(
+        "5.0.2",
+        sha256="2baa60b1d249c0af491a883f3fe4acd1d98a778136fef7713bbf69d83dc5c982",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="15a19af6009da3e9365684007cab7fa138d6040b01e365b0d2a8b2a0064d08e3",
+        deprecated=True,
+    )
 
     depends_on("cxx", type="build")  # generated
 
@@ -61,6 +76,6 @@ class Preferences(CMakePackage):
         args = []
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         if self.spec.satisfies("%intel"):
-            args.append("-DCMAKE_CXX_FLAGS=\"-std=c++11\"")
+            args.append('-DCMAKE_CXX_FLAGS="-std=c++11"')
 
         return args

--- a/spack_repo/lihpc/meshing/packages/pythonutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/pythonutil/package.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Pythonutil(CMakePackage):
+    """Utilitaires python-cpp."""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/pythonutil"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "pythonutil/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/pythonutil.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("tkutil")
+    depends_on("python", type=("build", "link"))
+    # On a besoin de swig >= 3.0.0 :
+    depends_on("swig@3:", type="build")
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    version("6.2.4", sha256="eeb7cd9740bfc1af6771a0c7b99b8cf51839eca409a01b2f6ba565bb36c89de6")
+    version("6.2.3", sha256="dc0e2bb9289e51b9678433cfc50385d5529e9b44f1b784d6ac9857be6d6089bf")
+    version("6.2.2", sha256="71d74499b53cbf865cc0d161e59358c5d535be407bde44e7fbca30e9232051b0")
+    version("6.2.1", sha256="14425325f2627bb410d9effb022aa0d1f7d7ee490766093668e3552630809acb")
+    version("6.2.0", sha256="6c513802336821be8895bc7f46bc580d80a564e2d7ec6c4ee2b1c7d6383a383f")
+    version("5.6.6", sha256="6edd64ff6ac22ea3483a551c49e490f77071aebe50d5586ece6f8ff929d6e84f")
+
+    depends_on("cxx", type="build")  # generated
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        # Fix cmake taking python3 even if `which python` is python2
+        py = self.spec["python"]
+        args.extend([
+            # find_package(PythonInterp) # Deprecated, but used by pybind11
+            self.define("PYTHON_EXECUTABLE", py.command.path),
+            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python_EXECUTABLE", py.command.path),
+            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+        ])
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/pythonutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/pythonutil/package.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Pythonutil(CMakePackage):
     """Utilitaires python-cpp."""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/pythonutil"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "pythonutil/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "pythonutil/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/pythonutil.git"
     maintainers = ["meshing_team"]
 
@@ -37,13 +40,15 @@ class Pythonutil(CMakePackage):
 
         # Fix cmake taking python3 even if `which python` is python2
         py = self.spec["python"]
-        args.extend([
-            # find_package(PythonInterp) # Deprecated, but used by pybind11
-            self.define("PYTHON_EXECUTABLE", py.command.path),
-            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python_EXECUTABLE", py.command.path),
-            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
-        ])
+        args.extend(
+            [
+                # find_package(PythonInterp) # Deprecated, but used by pybind11
+                self.define("PYTHON_EXECUTABLE", py.command.path),
+                # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python_EXECUTABLE", py.command.path),
+                # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+            ]
+        )
 
         return args

--- a/spack_repo/lihpc/meshing/packages/qqualif/package.py
+++ b/spack_repo/lihpc/meshing/packages/qqualif/package.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project QQualif
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qqualif(CMakePackage):
+    """Bibliotheque d'utilitaires de qualite de maillage."""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qqualif"
+    url = "https://github.com/LIHPC-Computational-Geometry/qqualif/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/qqualif.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("qwtcharts@4: ~shared", type=("build", "link"), when="~shared")
+    depends_on("qwtcharts@4: +shared", type=("build", "link"), when="+shared")
+    depends_on("vtkcontrib@4: ~shared", type=("build", "link"), when="~shared+vtk")
+    depends_on("vtkcontrib@4: +shared", type=("build", "link"), when="+shared+vtk")
+    depends_on("qualif@2: ~shared", type=("build", "link"), when="~shared")
+    depends_on("qualif@2: +shared", type=("build", "link"), when="+shared")
+    depends_on("gmds", type=("build", "link"), when="+gmds")
+    depends_on("lima", type=("build", "link"), when="+lima")
+    depends_on("vtk-maillage", type=("build", "link"), when="+vtk")
+
+# necessary because it is probably missing in the lima cmake files
+#    depends_on("machine-types", type=("build", "link"), when="+lima")
+
+    # patch in order to compile the hexagen test
+    # patch("qqualif-3.7.1_missing_lima_in_test.patch")
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+    variant("lima", default=True, description="Utilisation de la structure de maillages Lima")
+    variant("gmds", default=True, description="Utilisation de la structure de maillages GMDS")
+    variant("vtk", default=True, description="Utilisation de la structure de maillages VTK")
+
+    version("4.6.0", sha256="78fbbbd4919b5b6a96ee684e66baafa074c2a36328829ac120625e1a6540da14")
+    version("4.5.0", sha256="ae16c1e0c44a5ad3843e9bc7e6beca3d800ce0c887faf646e06b8f0dfb40363e")
+    version("4.4.0", sha256="0d8d315c1131ec36af92b6455880c4071ef3b06c36bebca55075c94b3e347224")
+    version("4.3.2", sha256="3be7b1615df727fecd8d590048745ea4fe51922c1745e0e78fe449a57aa28ab3")
+    version("4.3.1", sha256="93bf0c9cce52c7bc7157f3e728063d9699a88fb84875e649c31386cbab230b47")
+    version("4.3.0", sha256="4f7cfd222c207f634837ba93e319f0f57a18fcead04d1aa265ae825031c59537")
+    version("4.2.1", sha256="616f7411c1e07deb7257ee6ac398082e779d691d63b52d8e4eda382625d96380")
+    version("4.2.0", sha256="753182217c65ec4408fc5ea1e1d2a392ea0a662d5a977838ac5be2b09ff5af81")
+    version("3.9.1", sha256="bcc2a63ff842e59483bcafe68b09da17834f18b0bc6fecbad68638f85ba8f3e1")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("3.7.3",
+            sha256="26c7abf2bf4af3608a3777cfa33b67a017965d20681d2e38532aa67e4327442a",
+            deprecated=True)
+    version("3.7.1",
+            sha256="88f767746ec679990b6ca957825d58f374ab322caae53b60f1e48887bcb0c59d",
+            deprecated=True)
+    version("3.1.0",
+            sha256="51405815a2f7cf1472d98ba77836da7aa85abec035c7ac3da9f7f0178aae234e",
+            deprecated=True)
+    version("3.0.5",
+            sha256="400b8d308c6813d236b380742793a27c7169e8c89b894a6397c583fee52730cf",
+            deprecated=True)
+    version("3.0.4",
+            sha256="bcfa1f54962c9681417382155a5f7c2a2addfe01096804919cb0619ecbfd64ea",
+            deprecated=True)
+    version("3.0.2",
+            sha256="975bbe849a780e4d9edfbd25ecfde9db651b35a295a7939b3b243467cc6ab6e5",
+            deprecated=True)
+    version("3.0.1",
+            sha256="9a942e63fbcce101e8231215bd52fff00bca8106b3c9d0ffd01dbacd606c988c",
+            deprecated=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    def cmake_args(self):
+        # Since version 5.4.0 VtkContrib uses common_vtk.cmake of GUIToolkitsVariables which
+        # sets VTK 7, VTK 8 or VTK 9 to ON.
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("BUILD_GQLima", "lima"))
+        args.append(self.define_from_variant("BUILD_GQGMDS", "gmds"))
+        args.append(self.define_from_variant("BUILD_GQVtk", "vtk"))
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/qqualif/package.py
+++ b/spack_repo/lihpc/meshing/packages/qqualif/package.py
@@ -5,8 +5,9 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qqualif(CMakePackage):
@@ -28,8 +29,8 @@ class Qqualif(CMakePackage):
     depends_on("lima", type=("build", "link"), when="+lima")
     depends_on("vtk-maillage", type=("build", "link"), when="+vtk")
 
-# necessary because it is probably missing in the lima cmake files
-#    depends_on("machine-types", type=("build", "link"), when="+lima")
+    # necessary because it is probably missing in the lima cmake files
+    #    depends_on("machine-types", type=("build", "link"), when="+lima")
 
     # patch in order to compile the hexagen test
     # patch("qqualif-3.7.1_missing_lima_in_test.patch")
@@ -49,27 +50,41 @@ class Qqualif(CMakePackage):
     version("4.2.0", sha256="753182217c65ec4408fc5ea1e1d2a392ea0a662d5a977838ac5be2b09ff5af81")
     version("3.9.1", sha256="bcc2a63ff842e59483bcafe68b09da17834f18b0bc6fecbad68638f85ba8f3e1")
     # versions below are deprecated as sources are in the infinite void of space
-    version("3.7.3",
-            sha256="26c7abf2bf4af3608a3777cfa33b67a017965d20681d2e38532aa67e4327442a",
-            deprecated=True)
-    version("3.7.1",
-            sha256="88f767746ec679990b6ca957825d58f374ab322caae53b60f1e48887bcb0c59d",
-            deprecated=True)
-    version("3.1.0",
-            sha256="51405815a2f7cf1472d98ba77836da7aa85abec035c7ac3da9f7f0178aae234e",
-            deprecated=True)
-    version("3.0.5",
-            sha256="400b8d308c6813d236b380742793a27c7169e8c89b894a6397c583fee52730cf",
-            deprecated=True)
-    version("3.0.4",
-            sha256="bcfa1f54962c9681417382155a5f7c2a2addfe01096804919cb0619ecbfd64ea",
-            deprecated=True)
-    version("3.0.2",
-            sha256="975bbe849a780e4d9edfbd25ecfde9db651b35a295a7939b3b243467cc6ab6e5",
-            deprecated=True)
-    version("3.0.1",
-            sha256="9a942e63fbcce101e8231215bd52fff00bca8106b3c9d0ffd01dbacd606c988c",
-            deprecated=True)
+    version(
+        "3.7.3",
+        sha256="26c7abf2bf4af3608a3777cfa33b67a017965d20681d2e38532aa67e4327442a",
+        deprecated=True,
+    )
+    version(
+        "3.7.1",
+        sha256="88f767746ec679990b6ca957825d58f374ab322caae53b60f1e48887bcb0c59d",
+        deprecated=True,
+    )
+    version(
+        "3.1.0",
+        sha256="51405815a2f7cf1472d98ba77836da7aa85abec035c7ac3da9f7f0178aae234e",
+        deprecated=True,
+    )
+    version(
+        "3.0.5",
+        sha256="400b8d308c6813d236b380742793a27c7169e8c89b894a6397c583fee52730cf",
+        deprecated=True,
+    )
+    version(
+        "3.0.4",
+        sha256="bcfa1f54962c9681417382155a5f7c2a2addfe01096804919cb0619ecbfd64ea",
+        deprecated=True,
+    )
+    version(
+        "3.0.2",
+        sha256="975bbe849a780e4d9edfbd25ecfde9db651b35a295a7939b3b243467cc6ab6e5",
+        deprecated=True,
+    )
+    version(
+        "3.0.1",
+        sha256="9a942e63fbcce101e8231215bd52fff00bca8106b3c9d0ffd01dbacd606c988c",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/spack_repo/lihpc/meshing/packages/qqualif/qqualif-3.7.1_missing_lima_in_test.patch
+++ b/spack_repo/lihpc/meshing/packages/qqualif/qqualif-3.7.1_missing_lima_in_test.patch
@@ -1,0 +1,9 @@
+diff -Naur qqualif-3.7.1_orig/src/CMakeLists.txt qqualif-3.7.1_dest/src/CMakeLists.txt
+--- qqualif-3.7.1_orig/src/CMakeLists.txt	2020-11-09 13:15:46.000000000 +0100
++++ qqualif-3.7.1_dest/src/CMakeLists.txt	2020-11-23 09:44:40.841664825 +0100
+@@ -9,7 +9,7 @@
+ 	add_subdirectory (GQVtk)
+ endif (BUILD_GQVtk)
+ add_subdirectory (QtQualif)
+-add_subdirectory (QCalQual)
++#add_subdirectory (QCalQual)

--- a/spack_repo/lihpc/meshing/packages/qtpython/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtpython/package.py
@@ -5,8 +5,9 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qtpython(CMakePackage):
@@ -53,13 +54,15 @@ class Qtpython(CMakePackage):
 
         # Fix cmake taking python3 even if `which python` is python2
         py = self.spec["python"]
-        args.extend([
-            # find_package(PythonInterp) # Deprecated, but used by pybind11
-            self.define("PYTHON_EXECUTABLE", py.command.path),
-            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python_EXECUTABLE", py.command.path),
-            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
-        ])
+        args.extend(
+            [
+                # find_package(PythonInterp) # Deprecated, but used by pybind11
+                self.define("PYTHON_EXECUTABLE", py.command.path),
+                # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python_EXECUTABLE", py.command.path),
+                # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+            ]
+        )
 
         return args

--- a/spack_repo/lihpc/meshing/packages/qtpython/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtpython/package.py
@@ -24,11 +24,7 @@ class Qtpython(CMakePackage):
     depends_on("pythonutil@5: ~shared", type=("build", "link"), when="~shared")
     depends_on("qt")
 
-# 5.0.2 is the last python2 only version
-    depends_on("python@:2.999", type=("build", "link"), when="@:5.0.2")
-    depends_on("python", type=("build", "link"), when="@5.0.3:")
-#    depends_on("python@:2.999", type=("build", "link"))	# ==================== A REVOIR
-# On a besoin de swig >= 3.0.0 :
+    depends_on("python", type=("build", "link"))
     depends_on("swig@3:", type="build")
 
     variant("shared", default=True, description="Creation de bibliotheques dynamiques")
@@ -46,22 +42,6 @@ class Qtpython(CMakePackage):
     version("6.3.1", sha256="9191f353d63008f84aeebf9267202ad45ce7a6a04ee05b55bb076916c99de287")
     version("6.3.0", sha256="c6ccdb952ed6b9dfb393579eb82748e3c3c213da4ff8c254ec8e9eaea18ae338")
     version("5.1.10", sha256="ef9258f94a10c4124ad08ddac1824dfd616fc13e81bf3dabe8e8022578ed84fb")
-    # versions below are deprecated as sources are in the infinite void of space
-    version("5.1.1",
-            sha256="c6fe52a87cf38d28ed711dc47cd31ca3411cf5db962fe09531758340e7045844",
-            deprecated=True)
-    version("5.0.3",
-            sha256="2602f10437cdd1293caffbefefcdf104c146456d81f61b13ea0356533c63a2e0",
-            deprecated=True)
-    version("5.0.2",
-            sha256="587a91778f6797f056da3f54272e362b155ab427f63a7efd36db9fb739591881",
-            deprecated=True)
-    version("4.1.0",
-            sha256="870101ed2ef4e3424e3e9e03e83676186785dcd4e88e1ab6618f2bcbc9766112",
-            deprecated=True)
-    version("4.0.2",
-            sha256="f0b0749e26df7a01f70a30facbfeaad4eb410d1d9db6a78d731c1c35d2a97571",
-            deprecated=True)
 
     depends_on("cxx", type="build")  # generated
 

--- a/spack_repo/lihpc/meshing/packages/qtpython/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtpython/package.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project QtPython
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qtpython(CMakePackage):
+    """Bibliotheque d'utilitaires Qt/Python pour executer des scripts dans une console."""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qtpython"
+    url = "https://github.com/LIHPC-Computational-Geometry/qtpython/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/qtpython.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build", "link"))
+    depends_on("qtutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("qtutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("pythonutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("pythonutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("qt")
+
+# 5.0.2 is the last python2 only version
+    depends_on("python@:2.999", type=("build", "link"), when="@:5.0.2")
+    depends_on("python", type=("build", "link"), when="@5.0.3:")
+#    depends_on("python@:2.999", type=("build", "link"))	# ==================== A REVOIR
+# On a besoin de swig >= 3.0.0 :
+    depends_on("swig@3:", type="build")
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    version("6.4.7", sha256="7ff52e3bf8f8b83636d76b6a9a1a9b5a296e5110081511703b5ef2bb99749db8")
+    version("6.4.6", sha256="9f5acd88f4dbcc47fa1929a26466ab3aea0554ba87bfcd562bef701fefe7a1f5")
+    version("6.4.5", sha256="0a787b2b3ffc8c9a02cf134dd408b135d71b72ccaa2bef725aeb86440af4f0d8")
+    version("6.4.4", sha256="d70158ab0605623deeef24ca71e9ddbce1478afcf000b2ee5aa2fa922e3a59c2")
+    version("6.4.3", sha256="dcfee932c873f8d35b86e19bff95fca2aada7a2a631da2393546a9ed010fa5b4")
+    version("6.4.2", sha256="1a1967412fa11dcbac9e5eeb7361c1b5e013beb97dfa3c0717dee8e211206299")
+    version("6.4.1", sha256="439274455fe500d1f1bca2cef53433d2f4428ad96a57b060c4345872c04f9c64")
+    version("6.4.0", sha256="0ec68d7699450ef924cd1ab4c333cd1045451aa698a09184af56cc2f3db89c04")
+    version("6.3.3", sha256="060eb5832f39e1bd4c78e1abab7fad7dbcff2b098c9ac0764b6015bf46209d5b")
+    version("6.3.2", sha256="9abf42ee139fa392179e4b969b7bcf70cde9436ac7b02f3fb07e4e0077b17624")
+    version("6.3.1", sha256="9191f353d63008f84aeebf9267202ad45ce7a6a04ee05b55bb076916c99de287")
+    version("6.3.0", sha256="c6ccdb952ed6b9dfb393579eb82748e3c3c213da4ff8c254ec8e9eaea18ae338")
+    version("5.1.10", sha256="ef9258f94a10c4124ad08ddac1824dfd616fc13e81bf3dabe8e8022578ed84fb")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("5.1.1",
+            sha256="c6fe52a87cf38d28ed711dc47cd31ca3411cf5db962fe09531758340e7045844",
+            deprecated=True)
+    version("5.0.3",
+            sha256="2602f10437cdd1293caffbefefcdf104c146456d81f61b13ea0356533c63a2e0",
+            deprecated=True)
+    version("5.0.2",
+            sha256="587a91778f6797f056da3f54272e362b155ab427f63a7efd36db9fb739591881",
+            deprecated=True)
+    version("4.1.0",
+            sha256="870101ed2ef4e3424e3e9e03e83676186785dcd4e88e1ab6618f2bcbc9766112",
+            deprecated=True)
+    version("4.0.2",
+            sha256="f0b0749e26df7a01f70a30facbfeaad4eb410d1d9db6a78d731c1c35d2a97571",
+            deprecated=True)
+
+    depends_on("cxx", type="build")  # generated
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        args.append("-DBUILD_PY_CONSOLE:BOOL=ON")
+
+        # Fix cmake taking python3 even if `which python` is python2
+        py = self.spec["python"]
+        args.extend([
+            # find_package(PythonInterp) # Deprecated, but used by pybind11
+            self.define("PYTHON_EXECUTABLE", py.command.path),
+            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python_EXECUTABLE", py.command.path),
+            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+        ])
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/qtutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtutil/package.py
@@ -5,8 +5,9 @@
 # REPLACE_NAME_SERVICE_LABO, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qtutil(CMakePackage):
@@ -34,27 +35,37 @@ class Qtutil(CMakePackage):
     version("6.2.0", sha256="74a85acee94a676060197ac49179d82a9544f2baba871d4b2c1b1633317886bb")
     version("5.7.8", sha256="7073195a2cbfdae00840412d54ef7d8b8d60a6b28d9520a34e9b34fd3779bc5d")
     # versions below are deprecated as sources are in the infinite void of space
-    version("5.7.0",
-            sha256="a62fd6e85a8e45f42c3382edeb9a094e873cc479abf6f70efd3df0fb8188cc02",
-            deprecated=True)
-    version("5.1.0",
-            sha256="b3f1825ed7a4fb2039d47fad235ac819d61adc8faf4f1a70d8a3ed226bceb625",
-            deprecated=True)
-    version("5.0.3",
-            sha256="0368caf97f15683799423eb05f605884d187f3ad7e675855073840d49cccd269",
-            deprecated=True)
-    version("5.0.2",
-            sha256="9ca1d5fd687d90398ca45ca3e1a07f9d7c0b591943d231e8c088e026cb4d7cc2",
-            deprecated=True)
-    version("5.0.0",
-            sha256="c15f4c25a3db68ed90dc7ded6b53085a3f66181972936cdc247818b17f94dc21",
-            deprecated=True)
+    version(
+        "5.7.0",
+        sha256="a62fd6e85a8e45f42c3382edeb9a094e873cc479abf6f70efd3df0fb8188cc02",
+        deprecated=True,
+    )
+    version(
+        "5.1.0",
+        sha256="b3f1825ed7a4fb2039d47fad235ac819d61adc8faf4f1a70d8a3ed226bceb625",
+        deprecated=True,
+    )
+    version(
+        "5.0.3",
+        sha256="0368caf97f15683799423eb05f605884d187f3ad7e675855073840d49cccd269",
+        deprecated=True,
+    )
+    version(
+        "5.0.2",
+        sha256="9ca1d5fd687d90398ca45ca3e1a07f9d7c0b591943d231e8c088e026cb4d7cc2",
+        deprecated=True,
+    )
+    version(
+        "5.0.0",
+        sha256="c15f4c25a3db68ed90dc7ded6b53085a3f66181972936cdc247818b17f94dc21",
+        deprecated=True,
+    )
 
     depends_on("cxx", type="build")  # generated
 
     variant("shared", default=True, description="Création de bibliothèques dynamiques")
 
-# to avoid QtWebEngine or QtWebkit
+    # to avoid QtWebEngine or QtWebkit
     variant("qtbrowser", default=True, description="Use Qt base browser")
 
     def cmake_args(self):

--- a/spack_repo/lihpc/meshing/packages/qtutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtutil/package.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project QtUtil
+#
+# REPLACE_NAME_SERVICE_LABO, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qtutil(CMakePackage):
+    """Bibliotheque d'utilitaires Qt"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qtutil"
+    url = "https://github.com/LIHPC-Computational-Geometry/qtutil/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/qtutil.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("tkutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("tkutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("qt@5.9:", type=("build", "link"))
+
+    version("6.7.0", sha256="ed2e5553b28d56ae6d4450e1e17efe5d584cb456fbb67a5a31b16b85a0b76c3c")
+    version("6.6.1", sha256="0d81eddc7ad0947d0c2084e0b52207de972d35ad2bce2b993b749bef09d6710f")
+    version("6.6.0", sha256="84f639df33b1b2f697c0af6cd226adba3d36c211fee7d490b759b7fa6eb4a8c8")
+    version("6.5.0", sha256="113808d85915957e34777ab7a207830b5916d0db19c3f009a035ccc43940a27b")
+    version("6.4.2", sha256="e11596c5ccfbca313d628bbdadba0c59c5c8a24164f39525078e163012fa870f")
+    version("6.4.1", sha256="65a46bbd7818bf04f0addef12e9a35bdef118161cf46c75d0bbea929bed90373")
+    version("6.4.0", sha256="568f09a12c92810e27457ae1c589a0a9e89d3dd605194e5e1a429a0a3e18c96b")
+    version("6.3.0", sha256="183642b97f60053b3643a097124a8e4cad04447f5934f21d66715d9f17cdfa86")
+    version("6.2.1", sha256="0e8f0a75dca6574d4f348c4c2db3b5689a21cea94e6345a146235053ad4bbc4c")
+    version("6.2.0", sha256="74a85acee94a676060197ac49179d82a9544f2baba871d4b2c1b1633317886bb")
+    version("5.7.8", sha256="7073195a2cbfdae00840412d54ef7d8b8d60a6b28d9520a34e9b34fd3779bc5d")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("5.7.0",
+            sha256="a62fd6e85a8e45f42c3382edeb9a094e873cc479abf6f70efd3df0fb8188cc02",
+            deprecated=True)
+    version("5.1.0",
+            sha256="b3f1825ed7a4fb2039d47fad235ac819d61adc8faf4f1a70d8a3ed226bceb625",
+            deprecated=True)
+    version("5.0.3",
+            sha256="0368caf97f15683799423eb05f605884d187f3ad7e675855073840d49cccd269",
+            deprecated=True)
+    version("5.0.2",
+            sha256="9ca1d5fd687d90398ca45ca3e1a07f9d7c0b591943d231e8c088e026cb4d7cc2",
+            deprecated=True)
+    version("5.0.0",
+            sha256="c15f4c25a3db68ed90dc7ded6b53085a3f66181972936cdc247818b17f94dc21",
+            deprecated=True)
+
+    depends_on("cxx", type="build")  # generated
+
+    variant("shared", default=True, description="Création de bibliothèques dynamiques")
+
+# to avoid QtWebEngine or QtWebkit
+    variant("qtbrowser", default=True, description="Use Qt base browser")
+
+    def cmake_args(self):
+        args = []
+        args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+        args += [self.define_from_variant("USE_QT_TEXT_BROWSER", "qtbrowser")]
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/qtvtk/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtvtk/package.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project QtVTK
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qtvtk(CMakePackage):
+    """Bibliotheque d'utilitaires Qt/VTK"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qtvtk"
+    url = "https://github.com/LIHPC-Computational-Geometry/qtvtk/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/qtvtk.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("qtutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("qtutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("vtkcontrib@4: +shared", type=("build", "link"), when="+shared")
+    depends_on("vtkcontrib@4: ~shared", type=("build", "link"), when="~shared")
+    depends_on("preferences", type=("build", "link"))
+    depends_on("qt")
+    depends_on("vtk-maillage +qt", type=("build", "link"))
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    version("8.11.0", sha256="05ae61e6c36faba0060e381cae19ad575ebabe48d309b0f417f659bf26419681")
+    version("8.10.0", sha256="6c9094d7a903b5a859f1ed197976512153ec983ecc338f7f04890c44546100b5")
+    version("8.9.1", sha256="e9b8c107786b2d392b1abb64ef94f1827109bbb36a6c11265956e55eea8a6e27")
+    version("8.9.0", sha256="4f988ea4cb8e990262d5319ee6544eb904980c852d2ec50108c152534f1944a3")
+    version("8.8.4", sha256="436fc9ea484f308e529f8ba7c60e963c48e315dc6d22fabf6bccb34ea13d4568")
+    version("8.8.3", sha256="c1408a43b7d2832de99d2e3fa170ef7c7ed2a94e978b05eda5327b7ca0a7a500")
+    version("8.8.2", sha256="be755be155304572c7c2eae81a67c5ecbcd3dcd3aa6372d7f4afeb7ffaad6356")
+    version("8.8.1", sha256="bdbc864a487a1aede2a538e94db4182b787412bcdc75ef9f3fd602a35e7e58fa")
+    version("8.8.0", sha256="fd80c02a12628aba7a214dd23589028f2d8a1e4088a9140c661ee0d63b63dee7")
+    version("8.7.0", sha256="929bef89cf5a04c9214500667f741eba66c5885a2aeaedd7d05fc0f935146ad1")
+    version("8.6.0", sha256="95968e9fb03e6fe229efbbc70056a4e3184d4bb6879abdbeb7e84fc17695d869")
+    version("8.5.1", sha256="6a9ee744bde29ecdd157c23aff6036e614b03907dc05a6a3098fa1465e7360bc")
+    version("8.5.0", sha256="134ecd42a13e2409f3cbc9a634ec8d1ab0ed763cdb9c6c05a4ca72586af8b0b7")
+    version("8.4.1", sha256="8b5b0f74a27fd0664b4c94229d8488fb62fa34b2fd7a7367085215a2f850f786")
+    version("8.4.0", sha256="851bcf977d03f514dec6e1c220f3585e80ad043c4b11ef45805a5916b1c16d64")
+    version("7.14.8", sha256="2d9cb54c14afc38e849a25fe8fe534481402f64352c690454671e0e61a9fe0c4")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("7.14.0",
+            sha256="ff72228ae9762551e8c7be0def0a5e3289cb8c29427870beb34a375e02fec396",
+            deprecated=True)
+    version("7.13.1",
+            sha256="09c7d5b25ea6254650e994a0bfe97f96a3cd0c7e90df74f536d8b2e5b2f9e5d8",
+            deprecated=True)
+    version("7.13.0",
+            sha256="413b9776a81c51a9b3912d9de95ab04b4e3324a3e371f4759e690948bc9b8227",
+            deprecated=True)
+    version("7.1.0",
+            sha256="d70a3511cac971c0f18cbb322d32e1ef7dfae41816d1c189a7167289e89091d3",
+            deprecated=True)
+    version("7.0.1",
+            sha256="c5342f195c9f79fed62c572f405fdf67d009b89ce12e80e6fad80674dab92c06",
+            deprecated=True)
+    version("7.0.0",
+            sha256="75abca1906b3c6a535515a29be8fddbe1e1ff39c1bb609fe423d5bd309b8d61b",
+            deprecated=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    def cmake_args(self):
+        # Since version 5.4.0 VtkContrib uses common_vtk.cmake of GUIToolkitsVariables which
+        # sets VTK 7, VTK 8 or VTK 9 to ON.
+        args = []
+        # Sous spack on est en mode "production", ce qui conditionne le repertoire ou est l'aide :
+        args.append("-DPRODUCTION=ON")
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/qtvtk/package.py
+++ b/spack_repo/lihpc/meshing/packages/qtvtk/package.py
@@ -5,8 +5,9 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qtvtk(CMakePackage):
@@ -45,24 +46,36 @@ class Qtvtk(CMakePackage):
     version("8.4.0", sha256="851bcf977d03f514dec6e1c220f3585e80ad043c4b11ef45805a5916b1c16d64")
     version("7.14.8", sha256="2d9cb54c14afc38e849a25fe8fe534481402f64352c690454671e0e61a9fe0c4")
     # versions below are deprecated as sources are in the infinite void of space
-    version("7.14.0",
-            sha256="ff72228ae9762551e8c7be0def0a5e3289cb8c29427870beb34a375e02fec396",
-            deprecated=True)
-    version("7.13.1",
-            sha256="09c7d5b25ea6254650e994a0bfe97f96a3cd0c7e90df74f536d8b2e5b2f9e5d8",
-            deprecated=True)
-    version("7.13.0",
-            sha256="413b9776a81c51a9b3912d9de95ab04b4e3324a3e371f4759e690948bc9b8227",
-            deprecated=True)
-    version("7.1.0",
-            sha256="d70a3511cac971c0f18cbb322d32e1ef7dfae41816d1c189a7167289e89091d3",
-            deprecated=True)
-    version("7.0.1",
-            sha256="c5342f195c9f79fed62c572f405fdf67d009b89ce12e80e6fad80674dab92c06",
-            deprecated=True)
-    version("7.0.0",
-            sha256="75abca1906b3c6a535515a29be8fddbe1e1ff39c1bb609fe423d5bd309b8d61b",
-            deprecated=True)
+    version(
+        "7.14.0",
+        sha256="ff72228ae9762551e8c7be0def0a5e3289cb8c29427870beb34a375e02fec396",
+        deprecated=True,
+    )
+    version(
+        "7.13.1",
+        sha256="09c7d5b25ea6254650e994a0bfe97f96a3cd0c7e90df74f536d8b2e5b2f9e5d8",
+        deprecated=True,
+    )
+    version(
+        "7.13.0",
+        sha256="413b9776a81c51a9b3912d9de95ab04b4e3324a3e371f4759e690948bc9b8227",
+        deprecated=True,
+    )
+    version(
+        "7.1.0",
+        sha256="d70a3511cac971c0f18cbb322d32e1ef7dfae41816d1c189a7167289e89091d3",
+        deprecated=True,
+    )
+    version(
+        "7.0.1",
+        sha256="c5342f195c9f79fed62c572f405fdf67d009b89ce12e80e6fad80674dab92c06",
+        deprecated=True,
+    )
+    version(
+        "7.0.0",
+        sha256="75abca1906b3c6a535515a29be8fddbe1e1ff39c1bb609fe423d5bd309b8d61b",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/spack_repo/lihpc/meshing/packages/qualif/package.py
+++ b/spack_repo/lihpc/meshing/packages/qualif/package.py
@@ -5,8 +5,9 @@
 # REPLACE_NAME_SERVICE_LABO, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qualif(CMakePackage):
@@ -21,27 +22,41 @@ class Qualif(CMakePackage):
     depends_on("lima", type=("build", "link"))
     version("2.3.6", sha256="2c2993805248d218a56334c931af575bc0b0a89e0773f2211b9f88014bd2a135")
     # versions below are deprecated as sources are in the infinite void of space
-    version("2.3.5",
-            sha256="29a0135fc9d9348922d8513225b8e693b48c0dcb423c9d18cbff2278153c3794",
-            deprecated=True)
-    version("2.3.2",
-            sha256="c5049581fb01c240b6ea0662129d8a2ee9002901090e5be8805ed738ea1e34a7",
-            deprecated=True)
-    version("2.3.1",
-            sha256="b2a4f936539db69de061e5552bea780b098eca8221b40204a0888b9f9a3f7718",
-            deprecated=True)
-    version("2.1.0",
-            sha256="8ab87dd38752ecab4b4af73c8405d57b0daf5301a63e59f088649039ac4eb525",
-            deprecated=True)
-    version("2.0.2",
-            sha256="3ffcf3dee735a5d631f6e0f16422df9c22910156d0cbd82aa99b7733c89a7c41",
-            deprecated=True)
-    version("2.0.1",
-            sha256="28f01315224e4174c6ba44717afdfc3799560ec14488493f7d738122179092be",
-            deprecated=True)
-    version("2.0.0",
-            sha256="470cb7d25d34f2b19458c6a43e9ca5e3e2def7f3f4f0efdf0dbef5bbfe8dc9cc",
-            deprecated=True)
+    version(
+        "2.3.5",
+        sha256="29a0135fc9d9348922d8513225b8e693b48c0dcb423c9d18cbff2278153c3794",
+        deprecated=True,
+    )
+    version(
+        "2.3.2",
+        sha256="c5049581fb01c240b6ea0662129d8a2ee9002901090e5be8805ed738ea1e34a7",
+        deprecated=True,
+    )
+    version(
+        "2.3.1",
+        sha256="b2a4f936539db69de061e5552bea780b098eca8221b40204a0888b9f9a3f7718",
+        deprecated=True,
+    )
+    version(
+        "2.1.0",
+        sha256="8ab87dd38752ecab4b4af73c8405d57b0daf5301a63e59f088649039ac4eb525",
+        deprecated=True,
+    )
+    version(
+        "2.0.2",
+        sha256="3ffcf3dee735a5d631f6e0f16422df9c22910156d0cbd82aa99b7733c89a7c41",
+        deprecated=True,
+    )
+    version(
+        "2.0.1",
+        sha256="28f01315224e4174c6ba44717afdfc3799560ec14488493f7d738122179092be",
+        deprecated=True,
+    )
+    version(
+        "2.0.0",
+        sha256="470cb7d25d34f2b19458c6a43e9ca5e3e2def7f3f4f0efdf0dbef5bbfe8dc9cc",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/spack_repo/lihpc/meshing/packages/qualif/package.py
+++ b/spack_repo/lihpc/meshing/packages/qualif/package.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project Qualif
+#
+# REPLACE_NAME_SERVICE_LABO, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qualif(CMakePackage):
+    """Bibliotheque/utilitaire de mesure de qualite de maillage"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qualif"
+    url = "https://github.com/LIHPC-Computational-Geometry/qualif/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/qualif.git"
+
+    depends_on("cmake", type="build")
+    # On a besoin de 7.2 <= Lima :
+    depends_on("lima", type=("build", "link"))
+    version("2.3.6", sha256="2c2993805248d218a56334c931af575bc0b0a89e0773f2211b9f88014bd2a135")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("2.3.5",
+            sha256="29a0135fc9d9348922d8513225b8e693b48c0dcb423c9d18cbff2278153c3794",
+            deprecated=True)
+    version("2.3.2",
+            sha256="c5049581fb01c240b6ea0662129d8a2ee9002901090e5be8805ed738ea1e34a7",
+            deprecated=True)
+    version("2.3.1",
+            sha256="b2a4f936539db69de061e5552bea780b098eca8221b40204a0888b9f9a3f7718",
+            deprecated=True)
+    version("2.1.0",
+            sha256="8ab87dd38752ecab4b4af73c8405d57b0daf5301a63e59f088649039ac4eb525",
+            deprecated=True)
+    version("2.0.2",
+            sha256="3ffcf3dee735a5d631f6e0f16422df9c22910156d0cbd82aa99b7733c89a7c41",
+            deprecated=True)
+    version("2.0.1",
+            sha256="28f01315224e4174c6ba44717afdfc3799560ec14488493f7d738122179092be",
+            deprecated=True)
+    version("2.0.0",
+            sha256="470cb7d25d34f2b19458c6a43e9ca5e3e2def7f3f4f0efdf0dbef5bbfe8dc9cc",
+            deprecated=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    def cmake_args(self):
+        args = []
+        if "~shared" in self.spec:
+            args.append("-DBUILD_SHARED_LIBS:BOOL=OFF")
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/qwtcharts/package.py
+++ b/spack_repo/lihpc/meshing/packages/qwtcharts/package.py
@@ -5,16 +5,19 @@
 # REPLACE_NAME_SERVICE_LABO, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Qwtcharts(CMakePackage):
     """Bibliotheque d'utilitaires Qwt"""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/qwtcharts"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "qwtcharts/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "qwtcharts/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/qwtcharts.git"
     maintainers = ["meshing_team"]
 
@@ -30,24 +33,36 @@ class Qwtcharts(CMakePackage):
     version("5.2.0", sha256="5566d9bdd718f6c12b83f9bc03569ba61b3b67a54ef0ba39e72221ced985f706")
     version("4.4.13", sha256="e73544b6f94e2a3f989b74827bac5afbbf9c9a8899d991528d6f101f4fbc34d4")
     # versions below are deprecated as sources are in the infinite void of space
-    version("4.4.7",
-            sha256="e22528b70830e6ffa819ef032ab72307f218a65fa925a4c5f78a8510deedbae4",
-            deprecated=True)
-    version("4.4.6",
-            sha256="7e5e6d072e4ef01fc88d7cd7084a4eb8316ee03970536e0fc08598c07663d89e",
-            deprecated=True)
-    version("4.1.0",
-            sha256="47ecedb95db452edfde1efd8392e096ad5357517ddef17d09af6082df397ce12",
-            deprecated=True)
-    version("4.0.3",
-            sha256="03c2b1da97179c1702b75f48343eb4a36b5f8e516ed82cfeb32e4c29b7177e03",
-            deprecated=True)
-    version("4.0.2",
-            sha256="259164fbf009a275b90bf497362c5db42ad83f562a6747d22310c0eac4761f14",
-            deprecated=True)
-    version("4.0.0",
-            sha256="490c33b251b03ace8dd192cf775563fe9fd79ade51ebb8f30fcf023fd77ba000",
-            deprecated=True)
+    version(
+        "4.4.7",
+        sha256="e22528b70830e6ffa819ef032ab72307f218a65fa925a4c5f78a8510deedbae4",
+        deprecated=True,
+    )
+    version(
+        "4.4.6",
+        sha256="7e5e6d072e4ef01fc88d7cd7084a4eb8316ee03970536e0fc08598c07663d89e",
+        deprecated=True,
+    )
+    version(
+        "4.1.0",
+        sha256="47ecedb95db452edfde1efd8392e096ad5357517ddef17d09af6082df397ce12",
+        deprecated=True,
+    )
+    version(
+        "4.0.3",
+        sha256="03c2b1da97179c1702b75f48343eb4a36b5f8e516ed82cfeb32e4c29b7177e03",
+        deprecated=True,
+    )
+    version(
+        "4.0.2",
+        sha256="259164fbf009a275b90bf497362c5db42ad83f562a6747d22310c0eac4761f14",
+        deprecated=True,
+    )
+    version(
+        "4.0.0",
+        sha256="490c33b251b03ace8dd192cf775563fe9fd79ade51ebb8f30fcf023fd77ba000",
+        deprecated=True,
+    )
 
     depends_on("cxx", type="build")  # generated
 

--- a/spack_repo/lihpc/meshing/packages/qwtcharts/package.py
+++ b/spack_repo/lihpc/meshing/packages/qwtcharts/package.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project QwtCharts
+#
+# REPLACE_NAME_SERVICE_LABO, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Qwtcharts(CMakePackage):
+    """Bibliotheque d'utilitaires Qwt"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/qwtcharts"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "qwtcharts/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/qwtcharts.git"
+    maintainers = ["meshing_team"]
+
+    depends_on("guitoolkitsvariables", type=("build"))
+    depends_on("qtutil@5: +shared", type=("build", "link"), when="+shared")
+    depends_on("qtutil@5: ~shared", type=("build", "link"), when="~shared")
+    depends_on("qwt@6.1:", type=("build", "link"))
+
+    version("5.3.2", sha256="bd2ecda437c012bf616dfa19a6953bc751f1a80db3fc062f62c8ce7d7a874115")
+    version("5.3.1", sha256="8d46eef9d1944a482ba0321f457efa3736cd0f654341f8ab5f59560a8f363bbb")
+    version("5.3.0", sha256="71d7653d2887f124fe060bbaeea988f306e660a2eceeec33bf0b3baa0328be21")
+    version("5.2.1", sha256="fda34002a9631f7afcdb7cc4baaca81d09cacb0cd05b10fe08af86f091eddad5")
+    version("5.2.0", sha256="5566d9bdd718f6c12b83f9bc03569ba61b3b67a54ef0ba39e72221ced985f706")
+    version("4.4.13", sha256="e73544b6f94e2a3f989b74827bac5afbbf9c9a8899d991528d6f101f4fbc34d4")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("4.4.7",
+            sha256="e22528b70830e6ffa819ef032ab72307f218a65fa925a4c5f78a8510deedbae4",
+            deprecated=True)
+    version("4.4.6",
+            sha256="7e5e6d072e4ef01fc88d7cd7084a4eb8316ee03970536e0fc08598c07663d89e",
+            deprecated=True)
+    version("4.1.0",
+            sha256="47ecedb95db452edfde1efd8392e096ad5357517ddef17d09af6082df397ce12",
+            deprecated=True)
+    version("4.0.3",
+            sha256="03c2b1da97179c1702b75f48343eb4a36b5f8e516ed82cfeb32e4c29b7177e03",
+            deprecated=True)
+    version("4.0.2",
+            sha256="259164fbf009a275b90bf497362c5db42ad83f562a6747d22310c0eac4761f14",
+            deprecated=True)
+    version("4.0.0",
+            sha256="490c33b251b03ace8dd192cf775563fe9fd79ade51ebb8f30fcf023fd77ba000",
+            deprecated=True)
+
+    depends_on("cxx", type="build")  # generated
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    def cmake_args(self):
+        args = []
+        args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/smooth3d/package.py
+++ b/spack_repo/lihpc/meshing/packages/smooth3d/package.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+##############################################################################
+# Project Smooth3d
+#
+# Smooth3D is a mesh smoothing library
+#
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Smooth3d(CMakePackage):
+
+    """Smooth3D is a mesh smoothing library"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/smooth3d"
+    url = "https://github.com/LIHPC-Computational-Geometry/smooth3d/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/smooth3d.git"
+    maintainers = ["meshing_team"]
+
+    version("3.3.3", sha256="5f754f8a56d07451449891ed7048ea4e62dc8fbdee88d426e97e8629bcaa7665")
+    version("3.3.2", sha256="15dd83958c6e1febf8e6f68a92721adc01415637990b4823af24ce7001096548")
+    version("3.3.1", sha256="914e844330b88f2efb9fd26f37c8df76d4a4ab7136de34d0999ba77d2c5adae1")
+    version("3.3.0", sha256="2b392a2a4ed7b58ea503b423335369edf727e7c8e8054b2a321d4a2160b95a64")
+    version("3.2.1", sha256="e26fde58bebdf64134ae52fb6d1d1e95490c725a479370038c3093a46de4c837")
+    version("3.2.0", sha256="5e0132a5a6c75d18247db1fccfd7d64cdca7d9a8bb44c246616527a92fe809ea")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    variant("shared", default=True, description="Build as a shared library.")
+
+    depends_on("gmds")
+    depends_on("mesquite")
+    depends_on("lima")
+    depends_on("machine-types")
+
+    def cmake_args(self):
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/smooth3d/package.py
+++ b/spack_repo/lihpc/meshing/packages/smooth3d/package.py
@@ -7,12 +7,12 @@
 #
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Smooth3d(CMakePackage):
-
     """Smooth3D is a mesh smoothing library"""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/smooth3d"

--- a/spack_repo/lihpc/meshing/packages/tkutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/tkutil/package.py
@@ -20,9 +20,7 @@ class Tkutil(CMakePackage):
     extends("python")		# For the PYTHONPATH in the generated modules
 
     depends_on("guitoolkitsvariables", type=("build", "link"))
-    # 5.7.6 is the last python2 only version
-    depends_on("python@:2.999", type=("build", "link"), when="@:5.7.6")
-    depends_on("python", type=("build", "link"), when="@5.7.7:")
+    depends_on("python", type=("build", "link"))
     # On a besoin de swig >= 3.0.0 :
     depends_on("swig@3:", type=("build"))
     depends_on("libiconv", type=("build", "link"))
@@ -48,28 +46,6 @@ class Tkutil(CMakePackage):
     version("6.5.1", sha256="877ca71cc84cb4d948db8f5ecf65bae775cd33d83b2208c2d8260313238cc285")
     version("6.5.0", sha256="a1f1dc27fd0f5bcb8ddeee3f9d895c793f97e21d1cf395d1f607e29a47d0363e")
     version("5.14.0", sha256="e9fdc04f5a8efa4a95648a80422cfaccbb6733b79af2d49fe1af3ace4c748cb3")
-    # versions below are deprecated as sources are in the infinite void of space
-    version("5.7.7",
-            sha256="a9ed789f4088ba2bb3f1807d6317f74904fd10911b92cdb50f5c0e7f7ae61dea",
-            deprecated=True)
-    version("5.7.5",
-            sha256="335300ae3b441b45327d9b0fa4591c096509381b4c355d61fb407cb2eeea62fd",
-            deprecated=True)
-    version("5.7.2",
-            sha256="36406ad50fb73b07216f19ef34958abcf17171cc32a1d0fb44a7176aa97c03f3",
-            deprecated=True)
-    version("5.1.0",
-            sha256="949b97c14fcdddfc524978b472aa5129fe140049ada2b1e94717158c1a22b700",
-            deprecated=True)
-    version("5.0.3",
-            sha256="1fe8250cfd83c640266c54cc15687927f702cebd7d5e0a8396ea318e171f6b9a",
-            deprecated=True)
-    version("5.0.2",
-            sha256="7ca880377d069af81160458131c4c9c3d57bb24a7c1077f57d681abb02871669",
-            deprecated=True)
-    version("5.0.0",
-            sha256="9e049bbdf61ce49ff6e8bf246b94bc61a76896146f48b7aa5d5305346c6f9d50",
-            deprecated=True)
 
     depends_on("cxx", type="build")  # generated
 

--- a/spack_repo/lihpc/meshing/packages/tkutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/tkutil/package.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project TkUtil
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Tkutil(CMakePackage):
+    """Bibliothèque d'utilitaires C++"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/tkutil"
+    url = "https://github.com/LIHPC-Computational-Geometry/tkutil/archive/refs/tags/0.0.0.tar.gz"
+    git = "https://github.com/LIHPC-Computational-Geometry/tkutil.git"
+    maintainers = ["meshing_team"]
+
+    extends("python")		# For the PYTHONPATH in the generated modules
+
+    depends_on("guitoolkitsvariables", type=("build", "link"))
+    # 5.7.6 is the last python2 only version
+    depends_on("python@:2.999", type=("build", "link"), when="@:5.7.6")
+    depends_on("python", type=("build", "link"), when="@5.7.7:")
+    # On a besoin de swig >= 3.0.0 :
+    depends_on("swig@3:", type=("build"))
+    depends_on("libiconv", type=("build", "link"))
+
+    version("main", branch="main")
+    version("6.14.2", sha256="3b056ae6da37e86a347b32840f89196e9b17e03e7b00dcb3b241f1f94ba7dbd0")
+    version("6.14.1", sha256="1f9cf7dceddb61c78e2826f7cc10b2d2b2955cb79b7b7b30227cddcde9f69455")
+    version("6.14.0", sha256="96bc5d57e7bd0935c1fb6c93ddc585316f2148cda8a3e51c11e4db83f86bbf1e")
+    version("6.13.1", sha256="8c548d1bb57c8d84c42ec4f8643edd323a2cbd22a9180cd0822c10bcf49ca2c5")
+    version("6.13.0", sha256="c6df0badfaaa6b77cacdcd85aef79a628980a7367dc90c88df9959859d12af15")
+    version("6.12.1", sha256="8d53dca70dda7d8e28effde8d4dbd67eb215c27c3935db7cc75b09231cda469d")
+    version("6.12.0", sha256="459281ff909ce856a3641a8ea331a8d8801321ac5d20a2b3067ecb4a3afecbde")
+    version("6.11.0", sha256="51b6934c847e3728183abd3260829b5b0fb31f75d4f6e43422e271c2c09ea3b8")
+    version("6.10.3", sha256="d13279c80cc77902daecc5175429da703a85085a6a60fb839ccc3a428a10bed0")
+    version("6.10.2", sha256="d4ef63fa7e7357fc8bdaecab4d69c9a3c36ba479e5aa842628bf8b32e0edbcbf")
+    version("6.10.1", sha256="4f841f062b93465248c9a5e651080d40c621047422a04458dd87f81f1d5ad094")
+    version("6.10.0", sha256="a1521faa5123c569b93ece8874127996976f8ef44eb8d3f57280afb3a80e385d")
+    version("6.9.0", sha256="1fd2d1d525dac45277a8e9370252251f746946cd9b7b2b6440241e0f13aa27a0")
+    version("6.8.0", sha256="f9c1326f2725fec482db691ceda00882eba31c4db326bdddaf0f510a8b857afb")
+    version("6.7.0", sha256="5d610804c9061b09bad2cf799839a24a4de87667680943cc2bd8958f92bcf703")
+    version("6.6.1", sha256="1f65b2628992d455cdd0fb9b1e3e791432a3051ac2b138d4a7ef73dabc9e5d76")
+    version("6.6.0", sha256="9ae89bf5da6ed5af88e11325862df528c16166df49419b518c1c51a80019d0b8")
+    version("6.5.1", sha256="877ca71cc84cb4d948db8f5ecf65bae775cd33d83b2208c2d8260313238cc285")
+    version("6.5.0", sha256="a1f1dc27fd0f5bcb8ddeee3f9d895c793f97e21d1cf395d1f607e29a47d0363e")
+    version("5.14.0", sha256="e9fdc04f5a8efa4a95648a80422cfaccbb6733b79af2d49fe1af3ace4c748cb3")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("5.7.7",
+            sha256="a9ed789f4088ba2bb3f1807d6317f74904fd10911b92cdb50f5c0e7f7ae61dea",
+            deprecated=True)
+    version("5.7.5",
+            sha256="335300ae3b441b45327d9b0fa4591c096509381b4c355d61fb407cb2eeea62fd",
+            deprecated=True)
+    version("5.7.2",
+            sha256="36406ad50fb73b07216f19ef34958abcf17171cc32a1d0fb44a7176aa97c03f3",
+            deprecated=True)
+    version("5.1.0",
+            sha256="949b97c14fcdddfc524978b472aa5129fe140049ada2b1e94717158c1a22b700",
+            deprecated=True)
+    version("5.0.3",
+            sha256="1fe8250cfd83c640266c54cc15687927f702cebd7d5e0a8396ea318e171f6b9a",
+            deprecated=True)
+    version("5.0.2",
+            sha256="7ca880377d069af81160458131c4c9c3d57bb24a7c1077f57d681abb02871669",
+            deprecated=True)
+    version("5.0.0",
+            sha256="9e049bbdf61ce49ff6e8bf246b94bc61a76896146f48b7aa5d5305346c6f9d50",
+            deprecated=True)
+
+    depends_on("cxx", type="build")  # generated
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    def cmake_args(self):
+        args = []
+        args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+        args.append("-DCMAKE_CXX_FLAGS=\"-std=c++17\"")
+
+        # Fix cmake taking python3 even if `which python` is python2
+        py = self.spec["python"]
+        args.extend([
+            # find_package(PythonInterp) # Deprecated, but used by pybind11
+            self.define("PYTHON_EXECUTABLE", py.command.path),
+            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python_EXECUTABLE", py.command.path),
+            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+        ])
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/tkutil/package.py
+++ b/spack_repo/lihpc/meshing/packages/tkutil/package.py
@@ -5,8 +5,9 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Tkutil(CMakePackage):
@@ -17,7 +18,7 @@ class Tkutil(CMakePackage):
     git = "https://github.com/LIHPC-Computational-Geometry/tkutil.git"
     maintainers = ["meshing_team"]
 
-    extends("python")		# For the PYTHONPATH in the generated modules
+    extends("python")  # For the PYTHONPATH in the generated modules
 
     depends_on("guitoolkitsvariables", type=("build", "link"))
     depends_on("python", type=("build", "link"))
@@ -54,17 +55,19 @@ class Tkutil(CMakePackage):
     def cmake_args(self):
         args = []
         args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
-        args.append("-DCMAKE_CXX_FLAGS=\"-std=c++17\"")
+        args.append('-DCMAKE_CXX_FLAGS="-std=c++17"')
 
         # Fix cmake taking python3 even if `which python` is python2
         py = self.spec["python"]
-        args.extend([
-            # find_package(PythonInterp) # Deprecated, but used by pybind11
-            self.define("PYTHON_EXECUTABLE", py.command.path),
-            # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python_EXECUTABLE", py.command.path),
-            # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
-            self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
-        ])
+        args.extend(
+            [
+                # find_package(PythonInterp) # Deprecated, but used by pybind11
+                self.define("PYTHON_EXECUTABLE", py.command.path),
+                # find_package(Python) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python_EXECUTABLE", py.command.path),
+                # find_package(Python2/3) under cmake_minimum_required < 3.15 (CMP0094)
+                self.define("Python{}_EXECUTABLE".format(py.version[0]), py.command.path),
+            ]
+        )
 
         return args

--- a/spack_repo/lihpc/meshing/packages/vtkcontrib/package.py
+++ b/spack_repo/lihpc/meshing/packages/vtkcontrib/package.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Project VtkContrib
+#
+# CEA/DAM/DSSI, 2020
+##############################################################################
+
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class Vtkcontrib(CMakePackage):
+    """Bibliotheque d'utilitaires VTK"""
+
+    homepage = "https://github.com/LIHPC-Computational-Geometry/vtkcontrib"
+    url = ("https://github.com/LIHPC-Computational-Geometry/"
+           "vtkcontrib/archive/refs/tags/0.0.0.tar.gz")
+    git = "https://github.com/LIHPC-Computational-Geometry/vtkcontrib.git"
+    maintainers = ["meshing_team"]
+
+    # Rem : peu de variants pour VTK au regard de ce qui pourrait etre
+    # fait : opengl2, python, xdmf, qt, mpi, ffmpeg
+    # On veut dans cette version un VTK 7.*
+    #    depends_on("vtk@7.1:7.99~opengl2~python~xdmf+qt", type=("build", "link"))
+    #    depends_on("qt@5.9.1", type=("build", "link"))
+    depends_on("guitoolkitsvariables@1.5.99:", type=("build", "link"))
+    depends_on("vtk-maillage", type=("build", "link"))
+    #   depends_on("mpi", type=("build", "link"))
+
+    # for undefined reference in util-linux/libmount to intl_....
+    #    depends_on("gettext")
+
+    patch("vtkcontrib-4.6.0_calc_mpi.patch", when="@4.6.0")
+
+    version("5.17.0", sha256="0ada45a4019929244580091252ebb863d27220cdadfa5b65495f60e04fc8f1bf")
+    # Versions 5.15.0 and 5.16.*: linking problem.
+    # version("5.16.1", sha256="fb0abb649b6fdd3678f0560f1c4bbf3a5a6579e971d6a83db82abbed245b379a")
+    # version("5.16.0", sha256="d562c249a4e8c15a196112e6adddb6d06de0aeac408956b5c69825a3b1778533")
+    # version("5.15.0", sha256="8873286d247319293fe14e4c0dae5f2ecc43c03e07fbda381c23b9a920a6cd5f")
+    version("5.14.0", sha256="6aa8dd0fcb928cf43ee13a1e56fe783ffc69d2a3a8c2966d5470675befabffef")
+    version("5.13.1", sha256="baf8db650a705d1dfc72a48da38e272c0ef72024a029e982ceef1d35d6ef3422")
+    version("5.13.0", sha256="c2df1b2171fd72216e6279fa234e71203a7d3904e850bc3342fa2cee4f67e385")
+    version("5.12.0", sha256="6cbd668f33c3df5f48aa34687239ad3fdf76d0d5f3e71b20893b2ae3fcef34c9")
+    version("5.11.0", sha256="cdf69401fbb16f5d02546193ba49377852cdb6328a4bb00c0268869e05827e03")
+    version("5.10.0", sha256="7d2a940d43827eff135fbcd51345876ed10354656a8fffee455702b130a1e853")
+    version("5.9.0", sha256="eb6440b9c6cb386352f12faa420a61ed889c13c675856ed9846ffeaee259a632")
+    version("5.8.0", sha256="a8da685e29f302a5e2c78fd53eb9b8eb81d1d62b3a60dc03a9fab0e0f9fb196b")
+    version("5.7.1", sha256="000ff5ef5f2eb5873b110c479dff63a1705251c77275ae55fbaa5243aa8433e2")
+    version("5.7.0", sha256="71fdb9f29538fcf4076c8238f8ceb369c20e5a548982837d3b5543852a66a03a")
+    version("5.6.1", sha256="ef20de3d076e4b55b9e10aadfa2d5f1b25e21934b439c9c8afe00fa88e0164fa")
+    version("5.6.0", sha256="848c2576f870b3e3dc5cb1d84d3f073f676497d865109642c7ab05f355d5a4c4")
+    version("5.5.0", sha256="cb3056a9448fed7e738febc1382a5d1b6ae9ed29c0e1340f99dd03d0af913eba")
+    version("5.4.3", sha256="80f8b6e2f29f8d79e16f96874d4b5b336ca7e16e86d21f69376b285a0cd70469")
+    version("5.4.2", sha256="5d93d8051f4a1546932f201368bc2d4222ec617c1344dbc9ee1413beb7e24ec2")
+    version("5.4.1", sha256="de31db5778628eb8b01a67517379b2abe524944a038a348c00d65b1935ad0081")
+    version("5.4.0", sha256="c3c7d6b9491cbb273084ef1f5795e88599d23a041b568b61d1da426277cefcea")
+    version("4.6.4", sha256="1fce68d5c9342f90ff54aae75248679d52e303cf1954cdcf2ed0bf9bc6157a4c")
+    # versions below are deprecated as sources are in the infinite void of space
+    version("4.6.1",
+            sha256="8d32ff953f61addd0a40fa6a92c2ba8fe11f7431cc01608f45b8f7f681a7de76",
+            deprecated=True)
+    version("4.6.0",
+            sha256="269220824875c4945bdbdd78589d460b5a5ca806d78166c38079bb228e933e11",
+            deprecated=True)
+    version("4.0.1",
+            sha256="ea186d906ed63c9be0328067d08889dfe72b4fc1710831fc8234496f048003af",
+            deprecated=True)
+    version("4.0.0",
+            sha256="3ddcb0b3f5c06c93a8fc3ea9b7cb03e93d3f5ed4ec0d2ea2a48eab7c68529305",
+            deprecated=True)
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    variant("shared", default=True, description="Creation de bibliotheques dynamiques")
+
+    def cmake_args(self):
+        # Since version 5.4.0 VtkContrib uses common_vtk.cmake of GUIToolkitsVariables which
+        # sets VTK 7, VTK 8 or VTK 9 to ON.
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+
+        # if OFF does vtkcontrib uses OPENGL2 ?
+        # see VTK_OPENGL_BACKEND in src/VtkContrib/CMakeLists.txt
+        args.append("-DUSE_OPENGL_BACKEND:BOOL=ON")
+
+        return args

--- a/spack_repo/lihpc/meshing/packages/vtkcontrib/package.py
+++ b/spack_repo/lihpc/meshing/packages/vtkcontrib/package.py
@@ -5,16 +5,19 @@
 # CEA/DAM/DSSI, 2020
 ##############################################################################
 
-from spack.package import *
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class Vtkcontrib(CMakePackage):
     """Bibliotheque d'utilitaires VTK"""
 
     homepage = "https://github.com/LIHPC-Computational-Geometry/vtkcontrib"
-    url = ("https://github.com/LIHPC-Computational-Geometry/"
-           "vtkcontrib/archive/refs/tags/0.0.0.tar.gz")
+    url = (
+        "https://github.com/LIHPC-Computational-Geometry/"
+        "vtkcontrib/archive/refs/tags/0.0.0.tar.gz"
+    )
     git = "https://github.com/LIHPC-Computational-Geometry/vtkcontrib.git"
     maintainers = ["meshing_team"]
 
@@ -56,18 +59,26 @@ class Vtkcontrib(CMakePackage):
     version("5.4.0", sha256="c3c7d6b9491cbb273084ef1f5795e88599d23a041b568b61d1da426277cefcea")
     version("4.6.4", sha256="1fce68d5c9342f90ff54aae75248679d52e303cf1954cdcf2ed0bf9bc6157a4c")
     # versions below are deprecated as sources are in the infinite void of space
-    version("4.6.1",
-            sha256="8d32ff953f61addd0a40fa6a92c2ba8fe11f7431cc01608f45b8f7f681a7de76",
-            deprecated=True)
-    version("4.6.0",
-            sha256="269220824875c4945bdbdd78589d460b5a5ca806d78166c38079bb228e933e11",
-            deprecated=True)
-    version("4.0.1",
-            sha256="ea186d906ed63c9be0328067d08889dfe72b4fc1710831fc8234496f048003af",
-            deprecated=True)
-    version("4.0.0",
-            sha256="3ddcb0b3f5c06c93a8fc3ea9b7cb03e93d3f5ed4ec0d2ea2a48eab7c68529305",
-            deprecated=True)
+    version(
+        "4.6.1",
+        sha256="8d32ff953f61addd0a40fa6a92c2ba8fe11f7431cc01608f45b8f7f681a7de76",
+        deprecated=True,
+    )
+    version(
+        "4.6.0",
+        sha256="269220824875c4945bdbdd78589d460b5a5ca806d78166c38079bb228e933e11",
+        deprecated=True,
+    )
+    version(
+        "4.0.1",
+        sha256="ea186d906ed63c9be0328067d08889dfe72b4fc1710831fc8234496f048003af",
+        deprecated=True,
+    )
+    version(
+        "4.0.0",
+        sha256="3ddcb0b3f5c06c93a8fc3ea9b7cb03e93d3f5ed4ec0d2ea2a48eab7c68529305",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/spack_repo/lihpc/meshing/packages/vtkcontrib/vtkcontrib-4.6.0_calc_mpi.patch
+++ b/spack_repo/lihpc/meshing/packages/vtkcontrib/vtkcontrib-4.6.0_calc_mpi.patch
@@ -1,0 +1,36 @@
+diff -Naur vtkcontrib_orig/src/tests/CMakeLists.txt vtkcontrib_dest/src/tests/CMakeLists.txt
+--- vtkcontrib_orig/src/tests/CMakeLists.txt	2019-12-09 14:28:38.957843000 +0100
++++ vtkcontrib_dest/src/tests/CMakeLists.txt	2021-03-25 15:34:44.939082963 +0100
+@@ -8,10 +8,15 @@
+ target_include_directories (point_widget PRIVATE ../VtkContrib/public ${CMAKE_CURRENT_SOURCE_DIR})
+ target_compile_options (point_widget PRIVATE ${SHARED_CFLAGS}) # Requested by Qt ...
+ target_link_libraries (point_widget PUBLIC VtkContrib)
++
+ target_include_directories (trihedrons PRIVATE ../VtkContrib/public ${CMAKE_CURRENT_SOURCE_DIR})
+ target_compile_options (trihedrons PRIVATE ${SHARED_CFLAGS}) # Requested by Qt ...
+ target_link_libraries (trihedrons PUBLIC VtkContrib)
+ 
++# for libmount
++target_link_libraries (point_widget PUBLIC intl)
++target_link_libraries (trihedrons PUBLIC intl)
++
+ # INSTALL_RPATH modifie le rpath pour les libs internes au projet :
+ set_target_properties (point_widget PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1 INSTALL_RPATH ${CMAKE_PACKAGE_RPATH_DIR})
+ set_target_properties (trihedrons PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1 INSTALL_RPATH ${CMAKE_PACKAGE_RPATH_DIR})
+diff -Naur vtkcontrib_orig/src/VtkContrib/CMakeLists.txt vtkcontrib_dest/src/VtkContrib/CMakeLists.txt
+--- vtkcontrib_orig/src/VtkContrib/CMakeLists.txt	2021-02-01 08:42:31.149762000 +0100
++++ vtkcontrib_dest/src/VtkContrib/CMakeLists.txt	2021-03-25 14:59:40.892375454 +0100
+@@ -57,6 +57,13 @@
+ 	set (VTK_MPI_CFLAGS "${ompi_CFLAGS}" "${ompi_CFLAGS_OTHER}")
+ 	set (VTK_MPI_LDFLAGS "${ompi_LDFLAGS}" "${ompi_LDFLAGS_OTHER}")
+ 	set (VTK_MPI_LIBS "${ompi_LINK_LIBRARIES}")
++elseif (${PLATFORM} STREQUAL "Rhel_8__x86_64")
++        include (${CMAKE_SOURCE_DIR}/cmake/ompi.cmake)
++        set (VTK_MPI_LIB_DIR "${ompi_LIBRARY_DIRS}")
++        set (VTK_MPI_INC_DIR "${ompi_INCLUDE_DIRS}")
++        set (VTK_MPI_CFLAGS "${ompi_CFLAGS}" "${ompi_CFLAGS_OTHER}")
++        set (VTK_MPI_LDFLAGS "${ompi_LDFLAGS}" "${ompi_LDFLAGS_OTHER}")
++        set (VTK_MPI_LIBS "${ompi_LINK_LIBRARIES}")
+ elseif (${PLATFORM} STREQUAL "CentOS")
+ 	include (${CMAKE_SOURCE_DIR}/cmake/mpich.cmake)
+ 	set (VTK_MPI_LIB_DIR "${mpich_LIBRARY_DIRS}")

--- a/spack_repo/lihpc/meshing/repo.yaml
+++ b/spack_repo/lihpc/meshing/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: lihpc.meshing
+  api: v2.2

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/package.py
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/package.py
@@ -5,8 +5,10 @@
 
 
 import os
-from spack.package import *
+
 from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
 
 
 class VtkMaillage(CMakePackage):
@@ -16,7 +18,7 @@ class VtkMaillage(CMakePackage):
     v 1.5.0 du 07/06/24).
     The Visualization Toolkit (VTK) is an open-source, freely
     available software system for 3D computer graphics, image
-    processing and visualization. """
+    processing and visualization."""
 
     homepage = "http://www.vtk.org"
     url = "https://vtk.org/files/release/7.1/VTK-7.1.1.tar.gz"
@@ -91,35 +93,27 @@ class VtkMaillage(CMakePackage):
         cmake_args = [
             "-DBUILD_SHARED_LIBS=ON",
             "-DVTK_RENDERING_BACKEND:STRING={0}".format(opengl_ver),
-
             # In general, we disable use of VTK "ThirdParty" libs, preferring
             # spack-built versions whenever possible
             # "-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON",
             "-DVTK_USE_SYSTEM_LIBRARIES:BOOL=OFF",  # CP
-
             # However, in a few cases we can't do without them yet
             "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
             "-DVTK_USE_SYSTEM_LIBHARU=OFF",
             "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
             "-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF",
-
             # "-DNETCDF_DIR={0}".format(spec["netcdf"].prefix),
             # "-DNETCDF_C_ROOT={0}".format(spec["netcdf"].prefix),
             # "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
-
             # Allow downstream codes (e.g. VisIt) to override VTK's classes
             # "-DVTK_ALL_NEW_OBJECT_FACTORY:BOOL=ON",  # CP
-
             # Disable wrappers for other languages.
             "-DVTK_WRAP_JAVA=OFF",
             "-DVTK_WRAP_TCL=OFF",
         ]
 
         if "+mpi" in spec:
-            cmake_args.extend([
-                "-DVTK_Group_MPI:BOOL=ON",
-                "-DVTK_USE_SYSTEM_DIY2:BOOL=OFF",
-            ])
+            cmake_args.extend(["-DVTK_Group_MPI:BOOL=ON", "-DVTK_USE_SYSTEM_DIY2:BOOL=OFF"])
         else:
             cmake_args.append("-DVTK_Group_MPI:BOOL=OFF")
             cmake_args.append("-DVTK_USE_MPI=OFF")
@@ -134,12 +128,14 @@ class VtkMaillage(CMakePackage):
             qt_bin = spec["qt"].prefix.bin
             qmake_exe = os.path.join(qt_bin, "qmake")
 
-            cmake_args.extend([
-                # Enable Qt support here.
-                "-DVTK_QT_VERSION:STRING={0}".format(qt_ver),
-                "-DQT_QMAKE_EXECUTABLE:PATH={0}".format(qmake_exe),
-                "-DVTK_Group_Qt:BOOL=ON",
-            ])
+            cmake_args.extend(
+                [
+                    # Enable Qt support here.
+                    "-DVTK_QT_VERSION:STRING={0}".format(qt_ver),
+                    "-DQT_QMAKE_EXECUTABLE:PATH={0}".format(qmake_exe),
+                    "-DVTK_Group_Qt:BOOL=ON",
+                ]
+            )
 
             # NOTE: The following definitions are required in order to allow
             # VTK to build with qt~webkit versions (see the documentation for
@@ -153,35 +149,41 @@ class VtkMaillage(CMakePackage):
             #                ])
 
             # CP ADDON FLAGS :
-            cmake_args.extend([
-                "-DBUILD_SHARED_LIBS:BOOL=ON",
-                "-DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON",
-                "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
-                "-DModule_vtkIOExportOpenGL:BOOL=ON",
-                "-DModule_vtkImagingOpenGL:BOOL=ON",
-                "-DModule_vtkIOExportOpenGL2:BOOL=OFF",
-                "-DModule_vtkImagingOpenGL2:BOOL=OFF",
-                "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
-                "-DVTK_RENDERING_BACKEND=OpenGL",
-                "-DVTK_Group_Imaging:BOOL=ON",
-                "-DVTK_Group_Rendering:BOOL=ON",
-                "-DVTK_ALL_NEW_OBJECT_FACTORY=OFF",
-                # "-DVTK_QT_VERSION=5",
-                "-DVTK_USE_SYSTEM_NETCDF=OFF",
-                # "-DNETCDF_ENABLE_CXX=OFF",
-            ])
+            cmake_args.extend(
+                [
+                    "-DBUILD_SHARED_LIBS:BOOL=ON",
+                    "-DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON",
+                    "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
+                    "-DModule_vtkIOExportOpenGL:BOOL=ON",
+                    "-DModule_vtkImagingOpenGL:BOOL=ON",
+                    "-DModule_vtkIOExportOpenGL2:BOOL=OFF",
+                    "-DModule_vtkImagingOpenGL2:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
+                    "-DVTK_RENDERING_BACKEND=OpenGL",
+                    "-DVTK_Group_Imaging:BOOL=ON",
+                    "-DVTK_Group_Rendering:BOOL=ON",
+                    "-DVTK_ALL_NEW_OBJECT_FACTORY=OFF",
+                    # "-DVTK_QT_VERSION=5",
+                    "-DVTK_USE_SYSTEM_NETCDF=OFF",
+                    # "-DNETCDF_ENABLE_CXX=OFF",
+                ]
+            )
             if "+mpi" in spec:
-                cmake_args.extend([
-                    "-DModule_vtkParallelMPI:BOOL=ON",
-                    "-DModule_vtkFiltersParallelMPI:BOOL=ON",
-                    "-DModule_vtkRenderingParallel:BOOL=ON"
-                ])
+                cmake_args.extend(
+                    [
+                        "-DModule_vtkParallelMPI:BOOL=ON",
+                        "-DModule_vtkFiltersParallelMPI:BOOL=ON",
+                        "-DModule_vtkRenderingParallel:BOOL=ON",
+                    ]
+                )
             else:
-                cmake_args.extend([
-                    "-DModule_vtkParallelMPI:BOOL=OFF",
-                    "-DModule_vtkFiltersParallelMPI:BOOL=OFF",
-                    "-DModule_vtkRenderingParallel:BOOL=OFF"
-                ])
+                cmake_args.extend(
+                    [
+                        "-DModule_vtkParallelMPI:BOOL=OFF",
+                        "-DModule_vtkFiltersParallelMPI:BOOL=OFF",
+                        "-DModule_vtkRenderingParallel:BOOL=OFF",
+                    ]
+                )
             # !CP ADDON FLAGS
 
         if "+xdmf" in spec:
@@ -189,23 +191,25 @@ class VtkMaillage(CMakePackage):
                 # This policy exists only for CMake >= 3.12
                 cmake_args.extend(["-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"])
 
-            cmake_args.extend([
-                # Enable XDMF Support here
-                "-DModule_vtkIOXdmf2:BOOL=ON",
-                "-DModule_vtkIOXdmf3:BOOL=ON",
-                "-DBOOST_ROOT={0}".format(spec["boost"].prefix),
-                "-DBOOST_LIBRARY_DIR={0}".format(spec["boost"].prefix.lib),
-                "-DBOOST_INCLUDE_DIR={0}".format(spec["boost"].prefix.include),
-                "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
-                # This is needed because VTK has multiple FindBoost
-                # and they stick to system boost if there's a system boost
-                # installed with CMake
-                "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
-                "-DHDF5_ROOT={0}".format(spec["hdf5"].prefix),
-                # The xdmf project does not export any CMake file...
-                "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
-                "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF"
-            ])
+            cmake_args.extend(
+                [
+                    # Enable XDMF Support here
+                    "-DModule_vtkIOXdmf2:BOOL=ON",
+                    "-DModule_vtkIOXdmf3:BOOL=ON",
+                    "-DBOOST_ROOT={0}".format(spec["boost"].prefix),
+                    "-DBOOST_LIBRARY_DIR={0}".format(spec["boost"].prefix.lib),
+                    "-DBOOST_INCLUDE_DIR={0}".format(spec["boost"].prefix.include),
+                    "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
+                    # This is needed because VTK has multiple FindBoost
+                    # and they stick to system boost if there's a system boost
+                    # installed with CMake
+                    "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
+                    "-DHDF5_ROOT={0}".format(spec["hdf5"].prefix),
+                    # The xdmf project does not export any CMake file...
+                    "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF",
+                ]
+            )
 
             if "+mpi" in spec:
                 cmake_args.extend(["-DModule_vtkIOParallelXdmf3:BOOL=ON"])
@@ -216,10 +220,13 @@ class VtkMaillage(CMakePackage):
             cmake_args.append("-DVTK_USE_SYSTEM_GLEW:BOOL=ON")
 
         if "+osmesa" in spec:
-            cmake_args.extend([
-                "-DVTK_USE_X:BOOL=OFF",
-                "-DVTK_USE_COCOA:BOOL=OFF",
-                "-DVTK_OPENGL_HAS_OSMESA:BOOL=ON"])
+            cmake_args.extend(
+                [
+                    "-DVTK_USE_X:BOOL=OFF",
+                    "-DVTK_USE_COCOA:BOOL=OFF",
+                    "-DVTK_OPENGL_HAS_OSMESA:BOOL=ON",
+                ]
+            )
 
         else:
             cmake_args.append("-DVTK_OPENGL_HAS_OSMESA:BOOL=OFF")
@@ -228,20 +235,15 @@ class VtkMaillage(CMakePackage):
                 cmake_args.append("-DOpenGL_GL_PREFERENCE:STRING=LEGACY")
 
             if "darwin" in spec.architecture:
-                cmake_args.extend([
-                    "-DVTK_USE_X:BOOL=OFF",
-                    "-DVTK_USE_COCOA:BOOL=ON"])
+                cmake_args.extend(["-DVTK_USE_X:BOOL=OFF", "-DVTK_USE_COCOA:BOOL=ON"])
 
             elif "linux" in spec.architecture:
-                cmake_args.extend([
-                    "-DVTK_USE_X:BOOL=ON",
-                    "-DVTK_USE_COCOA:BOOL=OFF"])
+                cmake_args.extend(["-DVTK_USE_X:BOOL=ON", "-DVTK_USE_COCOA:BOOL=OFF"])
 
         if spec.satisfies("@:6.1.0"):
-            cmake_args.extend([
-                "-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY",
-                "-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY"
-            ])
+            cmake_args.extend(
+                ["-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY", "-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY"]
+            )
 
             # VTK 6.1.0 (and possibly earlier) does not use
             # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
@@ -262,12 +264,15 @@ class VtkMaillage(CMakePackage):
             # string. This fix was recommended on the VTK mailing list
             # in March 2014 (see
             # https://public.kitware.com/pipermail/vtkusers/2014-March/083368.html)
-            if (self.spec.satisfies("%clang") and self.compiler.is_apple and self.compiler.version >= Version("5.1.0")):
+            if (
+                self.spec.satisfies("%clang")
+                and self.compiler.is_apple
+                and self.compiler.version >= Version("5.1.0")
+            ):
                 cmake_args.extend(["-DVTK_REQUIRED_OBJCXX_FLAGS="])
 
             # A bug in tao pegtl causes build failures with intel compilers
             if "%intel" in spec and spec.version >= Version("8.2"):
-                cmake_args.append(
-                    "-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
+                cmake_args.append("-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
 
         return cmake_args

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/package.py
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/package.py
@@ -1,0 +1,273 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import os
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+
+class VtkMaillage(CMakePackage):
+    """Recette "pole maillage" de VTK, en vue d'eviter d'entrer en collision
+    avec toute autre recette de VTK.
+    Par défaut on désactive le backend OpenGL2 et MPI (GUIToolkitsVariables
+    v 1.5.0 du 07/06/24).
+    The Visualization Toolkit (VTK) is an open-source, freely
+    available software system for 3D computer graphics, image
+    processing and visualization. """
+
+    homepage = "http://www.vtk.org"
+    url = "https://vtk.org/files/release/7.1/VTK-7.1.1.tar.gz"
+
+    # VTK7 defaults to OpenGL2 rendering backend
+    variant("opengl2", default=False, description="Enable OpenGL2 backend")
+    variant("osmesa", default=False, description="Enable OSMesa support")
+    # variant("python", default=False, description="Enable Python support")
+    variant("qt", default=False, description="Build with support for Qt")
+    # variant("xdmf", default=False, description="Build XDMF file support")
+    # variant("ffmpeg", default=False, description="Build with FFMPEG support")
+    variant("mpi", default=False, description="Enable MPI support")
+
+    # At the moment, we cannot build with both osmesa and qt, but as of
+    # VTK 8.1, that should change
+    # conflicts("+osmesa", when="+qt")
+
+    # The use of the OpenGL2 backend requires at least OpenGL Core Profile
+    # version 3.2 or higher.
+    depends_on("gl@3.2:", when="+opengl2")
+    depends_on("gl@1.2:", when="~opengl2")
+
+    # Note: it is recommended to use mesa+llvm, if possible.
+    # mesa default is software rendering, llvm makes it faster
+    depends_on("mesa+osmesa", when="+osmesa")
+
+    # VTK will need Qt5OpenGL
+    depends_on("qt+opengl", when="+qt")
+    patch("vtk-maillage_qt515.patch", when="^qt@5.15:")
+
+    # when compiling vtk7 with gcc >= 10
+    patch("vtk-maillage_gcc10_hiddenvisibility.patch", when="%gcc@10:")
+
+    # when compiling vtk7 with gcc >= 11
+    patch("vtk-maillage_gcc11_const.patch", when="%gcc@11:")
+
+    # patch against underallocations for meshes of more than 10 million nodes/meshs
+    patch("vtk-maillage_vtkAbstractArray_SetNumberOfValues.patch")
+
+    depends_on("mpi", when="+mpi")
+
+    # depends_on("ffmpeg", when="+ffmpeg")
+    depends_on("expat")
+    depends_on("freetype")
+    depends_on("glew")
+    # depends_on("hdf5")
+    depends_on("jpeg")
+    # depends_on("jsoncpp")
+    # depends_on("libxml2")
+    # depends_on("lz4")
+    # depends_on("netcdf")
+    # depends_on("netcdf-cxx")
+    depends_on("libpng")
+    depends_on("libtiff")
+    depends_on("zlib")
+
+    #   def url_for_version(self, version):
+    #       url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"
+    #       return url.format(version.up_to(2), version)
+    version("7.1.1", sha256="2d5cdd048540144d821715c718932591418bb48f5b6bb19becdae62339efa75a")
+
+    def setup_environment(self, spack_env, run_env):
+        # VTK has some trouble finding freetype unless it is set in
+        # the environment
+        spack_env.set("FREETYPE_DIR", self.spec["freetype"].prefix)
+
+    def cmake_args(self):
+        spec = self.spec
+
+        opengl_ver = "OpenGL{0}".format("2" if "+opengl2" in spec else "")
+
+        cmake_args = [
+            "-DBUILD_SHARED_LIBS=ON",
+            "-DVTK_RENDERING_BACKEND:STRING={0}".format(opengl_ver),
+
+            # In general, we disable use of VTK "ThirdParty" libs, preferring
+            # spack-built versions whenever possible
+            # "-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON",
+            "-DVTK_USE_SYSTEM_LIBRARIES:BOOL=OFF",  # CP
+
+            # However, in a few cases we can't do without them yet
+            "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
+            "-DVTK_USE_SYSTEM_LIBHARU=OFF",
+            "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
+            "-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF",
+
+            # "-DNETCDF_DIR={0}".format(spec["netcdf"].prefix),
+            # "-DNETCDF_C_ROOT={0}".format(spec["netcdf"].prefix),
+            # "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
+
+            # Allow downstream codes (e.g. VisIt) to override VTK's classes
+            # "-DVTK_ALL_NEW_OBJECT_FACTORY:BOOL=ON",  # CP
+
+            # Disable wrappers for other languages.
+            "-DVTK_WRAP_JAVA=OFF",
+            "-DVTK_WRAP_TCL=OFF",
+        ]
+
+        if "+mpi" in spec:
+            cmake_args.extend([
+                "-DVTK_Group_MPI:BOOL=ON",
+                "-DVTK_USE_SYSTEM_DIY2:BOOL=OFF",
+            ])
+        else:
+            cmake_args.append("-DVTK_Group_MPI:BOOL=OFF")
+            cmake_args.append("-DVTK_USE_MPI=OFF")
+
+        if "+ffmpeg" in spec:
+            cmake_args.extend(["-DModule_vtkIOFFMPEG:BOOL=ON"])
+
+        cmake_args.append("-DVTK_WRAP_PYTHON=OFF")
+
+        if "+qt" in spec:
+            qt_ver = spec["qt"].version.up_to(1)
+            qt_bin = spec["qt"].prefix.bin
+            qmake_exe = os.path.join(qt_bin, "qmake")
+
+            cmake_args.extend([
+                # Enable Qt support here.
+                "-DVTK_QT_VERSION:STRING={0}".format(qt_ver),
+                "-DQT_QMAKE_EXECUTABLE:PATH={0}".format(qmake_exe),
+                "-DVTK_Group_Qt:BOOL=ON",
+            ])
+
+            # NOTE: The following definitions are required in order to allow
+            # VTK to build with qt~webkit versions (see the documentation for
+            # more info: http://www.vtk.org/Wiki/VTK/Tutorials/QtSetup).
+            # CP comments
+            #            if "~webkit" in spec["qt"]:
+            #                cmake_args.extend([
+            #                    "-DVTK_Group_Qt:BOOL=OFF",
+            #                    "-DModule_vtkGUISupportQt:BOOL=ON",
+            #                    "-DModule_vtkGUISupportQtOpenGL:BOOL=ON",
+            #                ])
+
+            # CP ADDON FLAGS :
+            cmake_args.extend([
+                "-DBUILD_SHARED_LIBS:BOOL=ON",
+                "-DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON",
+                "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
+                "-DModule_vtkIOExportOpenGL:BOOL=ON",
+                "-DModule_vtkImagingOpenGL:BOOL=ON",
+                "-DModule_vtkIOExportOpenGL2:BOOL=OFF",
+                "-DModule_vtkImagingOpenGL2:BOOL=OFF",
+                "-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF",
+                "-DVTK_RENDERING_BACKEND=OpenGL",
+                "-DVTK_Group_Imaging:BOOL=ON",
+                "-DVTK_Group_Rendering:BOOL=ON",
+                "-DVTK_ALL_NEW_OBJECT_FACTORY=OFF",
+                # "-DVTK_QT_VERSION=5",
+                "-DVTK_USE_SYSTEM_NETCDF=OFF",
+                # "-DNETCDF_ENABLE_CXX=OFF",
+            ])
+            if "+mpi" in spec:
+                cmake_args.extend([
+                    "-DModule_vtkParallelMPI:BOOL=ON",
+                    "-DModule_vtkFiltersParallelMPI:BOOL=ON",
+                    "-DModule_vtkRenderingParallel:BOOL=ON"
+                ])
+            else:
+                cmake_args.extend([
+                    "-DModule_vtkParallelMPI:BOOL=OFF",
+                    "-DModule_vtkFiltersParallelMPI:BOOL=OFF",
+                    "-DModule_vtkRenderingParallel:BOOL=OFF"
+                ])
+            # !CP ADDON FLAGS
+
+        if "+xdmf" in spec:
+            if spec.satisfies("^cmake@3.12:"):
+                # This policy exists only for CMake >= 3.12
+                cmake_args.extend(["-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"])
+
+            cmake_args.extend([
+                # Enable XDMF Support here
+                "-DModule_vtkIOXdmf2:BOOL=ON",
+                "-DModule_vtkIOXdmf3:BOOL=ON",
+                "-DBOOST_ROOT={0}".format(spec["boost"].prefix),
+                "-DBOOST_LIBRARY_DIR={0}".format(spec["boost"].prefix.lib),
+                "-DBOOST_INCLUDE_DIR={0}".format(spec["boost"].prefix.include),
+                "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
+                # This is needed because VTK has multiple FindBoost
+                # and they stick to system boost if there's a system boost
+                # installed with CMake
+                "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
+                "-DHDF5_ROOT={0}".format(spec["hdf5"].prefix),
+                # The xdmf project does not export any CMake file...
+                "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
+                "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF"
+            ])
+
+            if "+mpi" in spec:
+                cmake_args.extend(["-DModule_vtkIOParallelXdmf3:BOOL=ON"])
+
+        cmake_args.append("-DVTK_RENDERING_BACKEND:STRING=" + opengl_ver)
+
+        if spec.satisfies("@:8.1.0"):
+            cmake_args.append("-DVTK_USE_SYSTEM_GLEW:BOOL=ON")
+
+        if "+osmesa" in spec:
+            cmake_args.extend([
+                "-DVTK_USE_X:BOOL=OFF",
+                "-DVTK_USE_COCOA:BOOL=OFF",
+                "-DVTK_OPENGL_HAS_OSMESA:BOOL=ON"])
+
+        else:
+            cmake_args.append("-DVTK_OPENGL_HAS_OSMESA:BOOL=OFF")
+            if spec.satisfies("@:7.9.9"):
+                # This option is gone in VTK 8.1.2
+                cmake_args.append("-DOpenGL_GL_PREFERENCE:STRING=LEGACY")
+
+            if "darwin" in spec.architecture:
+                cmake_args.extend([
+                    "-DVTK_USE_X:BOOL=OFF",
+                    "-DVTK_USE_COCOA:BOOL=ON"])
+
+            elif "linux" in spec.architecture:
+                cmake_args.extend([
+                    "-DVTK_USE_X:BOOL=ON",
+                    "-DVTK_USE_COCOA:BOOL=OFF"])
+
+        if spec.satisfies("@:6.1.0"):
+            cmake_args.extend([
+                "-DCMAKE_C_FLAGS=-DGLX_GLXEXT_LEGACY",
+                "-DCMAKE_CXX_FLAGS=-DGLX_GLXEXT_LEGACY"
+            ])
+
+            # VTK 6.1.0 (and possibly earlier) does not use
+            # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
+            # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
+            # used instead to detect these bindings
+            #            netcdf_cxx_lib = spec["netcdf-cxx"].libs.joined()
+            #            cmake_args.extend([
+            #                "-DNETCDF_CXX_INCLUDE_DIR={0}".format(
+            #                    spec["netcdf-cxx"].prefix.include),
+            #                "-DNETCDF_CXX_LIBRARY={0}".format(netcdf_cxx_lib),
+            #            ])
+
+            # Garbage collection is unsupported in Xcode starting with
+            # version 5.1; if the Apple clang version of the compiler
+            # is 5.1.0 or later, unset the required Objective-C flags
+            # to remove the garbage collection flags.  Versions of VTK
+            # after 6.1.0 set VTK_REQUIRED_OBJCXX_FLAGS to the empty
+            # string. This fix was recommended on the VTK mailing list
+            # in March 2014 (see
+            # https://public.kitware.com/pipermail/vtkusers/2014-March/083368.html)
+            if (self.spec.satisfies("%clang") and self.compiler.is_apple and self.compiler.version >= Version("5.1.0")):
+                cmake_args.extend(["-DVTK_REQUIRED_OBJCXX_FLAGS="])
+
+            # A bug in tao pegtl causes build failures with intel compilers
+            if "%intel" in spec and spec.version >= Version("8.2"):
+                cmake_args.append(
+                    "-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
+
+        return cmake_args

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_gcc10_hiddenvisibility.patch
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_gcc10_hiddenvisibility.patch
@@ -1,0 +1,42 @@
+diff -Naur VTK-7.1.1_orig/CMake/VTKGenerateExportHeader.cmake VTK-7.1.1_dest/CMake/VTKGenerateExportHeader.cmake
+--- VTK-7.1.1_orig/CMake/VTKGenerateExportHeader.cmake	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/CMake/VTKGenerateExportHeader.cmake	2022-12-12 11:35:23.181784029 +0100
+@@ -214,8 +214,7 @@
+     check_cxx_compiler_flag(-fvisibility=hidden COMPILER_HAS_HIDDEN_VISIBILITY)
+     check_cxx_compiler_flag(-fvisibility-inlines-hidden
+       COMPILER_HAS_HIDDEN_INLINE_VISIBILITY)
+-    option(USE_COMPILER_HIDDEN_VISIBILITY
+-      "Use HIDDEN visibility support if available." ON)
++    option(USE_COMPILER_HIDDEN_VISIBILITY "Use HIDDEN visibility support if available." ON)
+     mark_as_advanced(USE_COMPILER_HIDDEN_VISIBILITY)
+   endif()
+ endmacro()
+@@ -375,11 +374,11 @@
+     return()
+   endif()
+ 
+-  set (EXTRA_FLAGS "-fvisibility=hidden")
++ # set (EXTRA_FLAGS "-fvisibility=hidden")	# CP comments in order to avoid undefined symbol (seems inefficient, use vtkModuleMacros.cmake patch)
+ 
+-  if(COMPILER_HAS_HIDDEN_INLINE_VISIBILITY)
+-    set (EXTRA_FLAGS "${EXTRA_FLAGS} -fvisibility-inlines-hidden")
+-  endif()
++ # if(COMPILER_HAS_HIDDEN_INLINE_VISIBILITY)
++ #   set (EXTRA_FLAGS "${EXTRA_FLAGS} -fvisibility-inlines-hidden")	# CP comments in order to avoid undefined symbol (seems inefficient, use vtkModuleMacros.cmake patch)
++ # endif()
+ 
+   # Either return the extra flags needed in the supplied argument, or to the
+   # CMAKE_CXX_FLAGS if no argument is supplied.
+diff -Naur VTK-7.1.1_orig/CMake/vtkModuleMacros.cmake VTK-7.1.1_dest/CMake/vtkModuleMacros.cmake
+--- VTK-7.1.1_orig/CMake/vtkModuleMacros.cmake	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/CMake/vtkModuleMacros.cmake	2022-12-12 11:36:32.708188423 +0100
+@@ -727,8 +727,7 @@
+       set_property(TARGET ${vtk-module}${target_suffix} APPEND
+         PROPERTY COMPILE_FLAGS "${my_abi_flags}")
+     else()
+-      set_property(TARGET ${vtk-module}${target_suffix}
+-        PROPERTY CXX_VISIBILITY_PRESET "hidden")
++#      set_property(TARGET ${vtk-module}${target_suffix}  PROPERTY CXX_VISIBILITY_PRESET "hidden")	# CP comments in order to avoid undefined symbol (pb with g++ 10/11, https://bugs.gentoo.org/723374)
+     endif()
+   endif()
+ 

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_gcc11_const.patch
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_gcc11_const.patch
@@ -1,0 +1,24 @@
+diff -Naur VTK-7.1.1_orig/Rendering/Label/vtkLabelHierarchy.cxx VTK-7.1.1_dest/Rendering/Label/vtkLabelHierarchy.cxx
+--- VTK-7.1.1_orig/Rendering/Label/vtkLabelHierarchy.cxx	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/Rendering/Label/vtkLabelHierarchy.cxx	2023-01-26 10:04:55.508689880 +0100
+@@ -525,7 +525,7 @@
+   {
+   public:
+     bool operator()(const vtkHierarchyNode & a,
+-                    const vtkHierarchyNode & b)
++                    const vtkHierarchyNode & b) const
+     {
+       if (a.Level != b.Level)
+       {
+diff -Naur VTK-7.1.1_orig/Rendering/Label/vtkLabelHierarchyPrivate.h VTK-7.1.1_dest/Rendering/Label/vtkLabelHierarchyPrivate.h
+--- VTK-7.1.1_orig/Rendering/Label/vtkLabelHierarchyPrivate.h	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/Rendering/Label/vtkLabelHierarchyPrivate.h	2023-01-26 10:06:38.030426667 +0100
+@@ -66,7 +66,7 @@
+     {
+     }
+ 
+-    bool operator () ( const vtkIdType& a, const vtkIdType& b )
++    bool operator () ( const vtkIdType& a, const vtkIdType& b ) const
+     {
+       if (0 == this->Hierarchy)
+       {

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_qt515.patch
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_qt515.patch
@@ -1,0 +1,22 @@
+diff -Naur VTK-7.1.1_orig/Rendering/Qt/vtkQtLabelRenderStrategy.cxx VTK-7.1.1_dest/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
+--- VTK-7.1.1_orig/Rendering/Qt/vtkQtLabelRenderStrategy.cxx	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/Rendering/Qt/vtkQtLabelRenderStrategy.cxx	2022-12-02 09:56:31.848078050 +0100
+@@ -40,6 +40,7 @@
+ #include <QImage>
+ #include <QMap>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPair>
+ #include <QPixmap>
+ #include <QTextDocument>
+diff -Naur VTK-7.1.1_orig/Rendering/Qt/vtkQtStringToImage.cxx VTK-7.1.1_dest/Rendering/Qt/vtkQtStringToImage.cxx
+--- VTK-7.1.1_orig/Rendering/Qt/vtkQtStringToImage.cxx	2017-03-20 16:26:17.000000000 +0100
++++ VTK-7.1.1_dest/Rendering/Qt/vtkQtStringToImage.cxx	2022-12-02 09:57:34.256396082 +0100
+@@ -31,6 +31,7 @@
+ #include <QFontMetrics>
+ #include <QImage>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPixmap>
+ #include <QTextDocument>
+ #include <QTextStream>

--- a/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_vtkAbstractArray_SetNumberOfValues.patch
+++ b/spack_repo/lihpc/meshing_supersede/packages/vtk_maillage/vtk-maillage_vtkAbstractArray_SetNumberOfValues.patch
@@ -1,0 +1,23 @@
+diff -Naur VTK-7.1.1.old/Common/Core/vtkAbstractArray.cxx VTK-7.1.1/Common/Core/vtkAbstractArray.cxx
+--- VTK-7.1.1.old/Common/Core/vtkAbstractArray.cxx	2023-11-10 08:09:27.968215356 +0100
++++ VTK-7.1.1/Common/Core/vtkAbstractArray.cxx	2023-11-10 08:20:58.107217364 +0100
+@@ -187,8 +187,17 @@
+ //----------------------------------------------------------------------------
+ void vtkAbstractArray::SetNumberOfValues(vtkIdType numValues)
+ {
+-  if (this->Resize(std::ceil(numValues /
+-                             static_cast<float>(this->NumberOfComponents))))
++/* VTK code 7.1.1.
++ * If NumberOfComponents is 1 and numValues ​​is 46640545, then numValues ​​/static_cast<float>(this->NumberOfComponents),
++ * of floating type, will be 46640544 (the floating precision is 7 significant digits,
++ * cf. https://www.h-schmidt .net/FloatConverter/IEEE754.html)
++ * => insufficient memory allocation causing crash and revealed by valgrind
++ * if (this->Resize(std::ceil(numValues /
++ *                            static_cast<float>(this->NumberOfComponents))))
++*/
++// Replacement VTK 8.2.0 code :
++  vtkIdType numTuples = this->NumberOfComponents == 1 ? numValues : (numValues + this->NumberOfComponents - 1) / this->NumberOfComponents;
++  if (this->Resize(numTuples))
+   {
+     this->MaxId = numValues - 1;
+   }

--- a/spack_repo/lihpc/meshing_supersede/repo.yaml
+++ b/spack_repo/lihpc/meshing_supersede/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: lihpc.meshing_supersede
+  api: v2.2


### PR DESCRIPTION
- the 2 repos *meshing* and *meshing_supersede* where migrated using the `spack repo migrate ...` command.
- the directories layout follow the [spack recommendation](https://spack.readthedocs.io/en/v1.1.1/repositories.html#structure-of-an-individual-package-repository)
- namespaces for lihpc repos where defined as `lihpc.meshing` and `lihpc.meshing_supersede`.
- machine-types mock package was not deleted, but probably should when @obressand-cea will release it on github.
- the migrating process forgot about a few `depends_on("c")` and missed `spack -> spack.package` imports (fixed in a separated commit).
- Dockerfile and shell script use now spack v1.1.1 but should be tested. (recipe repo artificially point on this branch)
- removed deprecated version as python2 isn't available anymore with spack-v1
- it seems the eigen deps is fixed on 3.3 by cmake which is not the case in the recipes
- qwtcharts need a qwt_compat.h only available until qwt-6.1, this constraint should probably be expressed in it's recipe.

Lastly, this MR should only be merged when production is ready to use spack-v1